### PR TITLE
Save and load resume data

### DIFF
--- a/src/components/workMenu.svelte
+++ b/src/components/workMenu.svelte
@@ -23,6 +23,7 @@
     highlights.update((highlights) => {
       const currVisibility = highlights[i].visible;
       highlights[i].visible = !currVisibility;
+      saveResumeData();
       return highlights;
     });
   }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -136,25 +136,28 @@ export function saveResumeData(
   window.localStorage.setItem('saveData', JSON.stringify(saveData));
 }
 
-export function loadLocalStorageData() {
+export function loadLocalStorageData(
+  basics: BasicsStore = basicsStore,
+  work: Writable<WorkStore[]> = workStores
+) {
   const saveDataString = localStorage.getItem('saveData');
   if (saveDataString != null) {
     const saveData: SaveData = JSON.parse(saveDataString);
     // load basic data
-    basicsStore.name.set(saveData.basics.name);
-    basicsStore.label.set(saveData.basics.label);
-    basicsStore.image.set(saveData.basics.image);
-    basicsStore.label.set(saveData.basics.label);
-    basicsStore.phone.set(saveData.basics.phone);
-    basicsStore.email.set(saveData.basics.email);
-    basicsStore.summary.set(saveData.basics.summary);
+    basics.name.set(saveData.basics.name);
+    basics.label.set(saveData.basics.label);
+    basics.image.set(saveData.basics.image);
+    basics.label.set(saveData.basics.label);
+    basics.phone.set(saveData.basics.phone);
+    basics.email.set(saveData.basics.email);
+    basics.summary.set(saveData.basics.summary);
 
     // load work data
     const workStoresArray: WorkStore[] = [];
     saveData.work.forEach((work) => {
       workStoresArray.push(new WorkStore(work));
     });
-    workStores.set(workStoresArray);
+    work.set(workStoresArray);
   } else {
     console.error('Failed to load resume save data from localStorage!');
   }

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -84,7 +84,7 @@ export class WorkStore {
   startDate = writable('');
   endDate = writable('');
   summary = writable('');
-  highlights = writable([{ visible: true, content: '' }]);
+  highlights: Writable<Highlight[]> = writable([]);
 
   constructor(params: Work = blankWork) {
     this.name.set(params.name);
@@ -105,20 +105,23 @@ type SaveData = {
 /**
  * Takes data from Basics, Work, and Education stores and saves it to localStorage as a JSON blob
  */
-export function saveResumeData() {
+export function saveResumeData(
+  basics: BasicsStore = basicsStore,
+  work: Writable<WorkStore[]> = workStores
+) {
   const saveData: SaveData = {
     basics: {
-      name: get(basicsStore.name),
-      label: get(basicsStore.label),
-      image: get(basicsStore.image),
-      phone: get(basicsStore.phone),
-      email: get(basicsStore.email),
-      summary: get(basicsStore.summary)
+      name: get(basics.name),
+      label: get(basics.label),
+      image: get(basics.image),
+      phone: get(basics.phone),
+      email: get(basics.email),
+      summary: get(basics.summary)
     },
     work: []
   };
 
-  get(workStores).forEach((ws: WorkStore) => {
+  get(work).forEach((ws: WorkStore) => {
     saveData.work.push({
       name: get(ws.name),
       position: get(ws.position),
@@ -130,7 +133,7 @@ export function saveResumeData() {
     });
   });
 
-  localStorage.setItem('saveData', JSON.stringify(saveData));
+  window.localStorage.setItem('saveData', JSON.stringify(saveData));
 }
 
 export function loadLocalStorageData() {
@@ -188,4 +191,4 @@ export function loadJSONResumeData(jsonResume: string): [BasicsStore, Writable<W
 }
 
 export const basicsStore = new BasicsStore();
-export const workStores = writable([new WorkStore()]);
+export const workStores: Writable<WorkStore[]> = writable([]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
-  import { mockResume } from '@src/data/mockResume';
   import Menu from '@src/components/menu.svelte';
   import Resume from '@src/components/resume.svelte';
-  import { BasicsStore, WorkStore, loadResumeData } from '@src/data/data';
-  import { writable, type Writable } from 'svelte/store';
+  import { basicsStore, workStores, loadLocalStorageData } from '@src/data/data';
+  import { onMount } from 'svelte';
 
-  let basicsStore: BasicsStore = new BasicsStore();
-  let workStores: Writable<WorkStore[]> = writable([new WorkStore()]);
-
-  [basicsStore, workStores] = loadResumeData(mockResume);
+  onMount(() => {
+    loadLocalStorageData();
+  });
 </script>
 
 <Menu basics={basicsStore} work={workStores} />

--- a/tests/data/data.spec.ts
+++ b/tests/data/data.spec.ts
@@ -1,11 +1,23 @@
-import { saveResumeData } from '@src/data/data';
+import { saveResumeData, loadLocalStorageData, BasicsStore, type WorkStore } from '@src/data/data';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Writable, writable, get } from 'svelte/store';
+
+const blankSaveData = JSON.stringify({
+  basics: {
+    name: '',
+    label: '',
+    image: '',
+    phone: '',
+    email: '',
+    summary: ''
+  },
+  work: []
+});
 
 describe('saveResumeData', () => {
   beforeEach(() => {
     vi.stubGlobal('localStorage', {
-      setItem: vi.fn(),
-      getItem: vi.fn()
+      setItem: vi.fn()
     });
   });
 
@@ -14,19 +26,53 @@ describe('saveResumeData', () => {
   });
 
   it('saves data to localStorage', () => {
-    const expectedSaveData = JSON.stringify({
-      basics: {
-        name: '',
-        label: '',
-        image: '',
-        phone: '',
-        email: '',
-        summary: ''
-      },
-      work: []
-    });
+    const expectedSaveData = blankSaveData;
     saveResumeData();
     expect(localStorage.setItem).toHaveBeenCalledOnce();
     expect(localStorage.setItem).toHaveBeenCalledWith('saveData', expectedSaveData);
+  });
+});
+
+describe('loadLocalStorageData', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('loads data from localStorage', () => {
+    const fakeLocalStorage = blankSaveData;
+    const basicsStore = new BasicsStore();
+    const workStores: Writable<WorkStore[]> = writable([]);
+
+    vi.stubGlobal('localStorage', {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      getItem: (key: string) => {
+        return fakeLocalStorage;
+      }
+    });
+
+    loadLocalStorageData(basicsStore, workStores);
+    expect(get(basicsStore.name)).toBe('');
+    expect(get(basicsStore.image)).toBe('');
+    expect(get(basicsStore.label)).toBe('');
+    expect(get(basicsStore.phone)).toBe('');
+    expect(get(basicsStore.email)).toBe('');
+    expect(get(basicsStore.summary)).toBe('');
+    expect(get(workStores)).toStrictEqual([]);
+  });
+
+  it('errors in the console if no save data is loaded', () => {
+    vi.stubGlobal('localStorage', {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      getItem: (key: string) => {
+        return null;
+      }
+    });
+    vi.stubGlobal('console', {
+      error: vi.fn()
+    });
+
+    loadLocalStorageData();
+
+    expect(console.error).toHaveBeenCalledOnce();
   });
 });

--- a/tests/data/data.spec.ts
+++ b/tests/data/data.spec.ts
@@ -1,0 +1,32 @@
+import { saveResumeData } from '@src/data/data';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('saveResumeData', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', {
+      setItem: vi.fn(),
+      getItem: vi.fn()
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('saves data to localStorage', () => {
+    const expectedSaveData = JSON.stringify({
+      basics: {
+        name: '',
+        label: '',
+        image: '',
+        phone: '',
+        email: '',
+        summary: ''
+      },
+      work: []
+    });
+    saveResumeData();
+    expect(localStorage.setItem).toHaveBeenCalledOnce();
+    expect(localStorage.setItem).toHaveBeenCalledWith('saveData', expectedSaveData);
+  });
+});


### PR DESCRIPTION
Saves and loads data from `localStorage` into the app. Saves when the user changes fields, and loads when the user opens the page for the first time. Also added unit tests.