### PR TITLE
Fix pre-commit hook in husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm format
+git add .


### PR DESCRIPTION
For a while, I've had to `git commit --amend` any changes that occurred after the formatting was completed in the pre-hook commit step. Now, when formatting takes place, it's automatically added to the commit before finishing the commit. No more amending commits!