### PR TITLE
Fix resume work display swapping

### DIFF
--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -120,7 +120,7 @@ test.describe('Work experience menu input', () => {
       await addWorkExperience(page);
       await page.locator('#work_0_newHighlight').click();
       const tagName = 'tagName';
-      const tagsInput = page.locator('#work_0_highlight_0_tags_input');
+      const tagsInput = page.locator('#work_0_highlight_0_tagsInput');
       await tagsInput.type(tagName);
       await tagsInput.press('Enter');
       const tagId = `#work_0_highlight_0_tag_${tagName}`;
@@ -169,7 +169,9 @@ test.describe('Work experience menu input', () => {
         name: 'Work 1 Name',
         position: 'Work 1 Position',
         startDate: '2001-01',
+        decoratedStartDate: 'January 2001',
         endDate: '2001-12',
+        decoratedEndDate: 'December 2001',
         highlight: 'Work 1 highlight'
       };
 
@@ -177,7 +179,9 @@ test.describe('Work experience menu input', () => {
         name: 'Work 2 Name',
         position: 'Work 2 Position',
         startDate: '2002-01',
+        decoratedStartDate: 'January 2002',
         endDate: '2002-12',
+        decoratedEndDate: 'December 2002',
         highlight: 'Work 2 highlight'
       };
 
@@ -217,17 +221,17 @@ test.describe('Work experience menu input', () => {
       await expect(page.locator('#work_1_highlight_0')).toHaveValue(work1.highlight);
 
       // verify the swap is correct in the resume component
-      await expect(page.locator('#resume_work_0_name')).toHaveValue(work2.name);
-      await expect(page.locator('#resume_work_0_position')).toHaveValue(work2.position);
-      await expect(page.locator('#resume_work_0_startDate')).toHaveValue(work2.startDate);
-      await expect(page.locator('#resume_work_0_endDate')).toHaveValue(work2.endDate);
-      await expect(page.locator('#resume_work_0_highlight_0')).toHaveValue(work2.highlight);
+      await expect(page.locator('#resume_work_0_name')).toHaveText(work2.name);
+      await expect(page.locator('#resume_work_0_position')).toHaveText(work2.position);
+      await expect(page.locator('#resume_work_0_startDate')).toHaveText(work2.decoratedStartDate);
+      await expect(page.locator('#resume_work_0_endDate')).toHaveText(work2.decoratedEndDate);
+      await expect(page.locator('#resume_work_0_highlight_0')).toHaveText(work2.highlight);
 
-      await expect(page.locator('#resume_work_1_name')).toHaveValue(work1.name);
-      await expect(page.locator('#resume_work_1_position')).toHaveValue(work1.position);
-      await expect(page.locator('#resume_work_1_startDate')).toHaveValue(work1.startDate);
-      await expect(page.locator('#resume_work_1_endDate')).toHaveValue(work1.endDate);
-      await expect(page.locator('#resume_work_1_highlight_0')).toHaveValue(work1.highlight);
+      await expect(page.locator('#resume_work_1_name')).toHaveText(work1.name);
+      await expect(page.locator('#resume_work_1_position')).toHaveText(work1.position);
+      await expect(page.locator('#resume_work_1_startDate')).toHaveText(work1.decoratedStartDate);
+      await expect(page.locator('#resume_work_1_endDate')).toHaveText(work1.decoratedEndDate);
+      await expect(page.locator('#resume_work_1_highlight_0')).toHaveText(work1.highlight);
     });
   });
 });

--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -130,5 +130,104 @@ test.describe('Work experience menu input', () => {
       await page.locator(`#work_0_highlight_0_delete_tag_${tagName}`).click();
       await expect(page.locator(tagId)).not.toBeVisible();
     });
+
+    test('Changing the order of highlights updates the list of highlights in the resume properly', async ({
+      page
+    }) => {
+      await addWorkExperience(page);
+      // fill in highlights
+      const firstHighlight = 'First highlight';
+      const secondHighlight = 'Second highlight';
+      const firstHighlightLocator = page.locator('#work_0_highlight_0');
+      const secondHighlightLocator = page.locator('#work_0_highlight_1');
+      await page.locator('#work_0_newHighlight').click();
+      await firstHighlightLocator.fill(firstHighlight);
+      await page.locator('#work_0_newHighlight').click();
+      await secondHighlightLocator.fill(secondHighlight);
+
+      // move first highlight down and verify
+      await page.locator('#work_0_highlight_0_down').click();
+      await expect(page.locator('#work_0_highlight_0')).toHaveValue(secondHighlight);
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_0', secondHighlight);
+      await expect(page.locator('#work_0_highlight_1')).toHaveValue(firstHighlight);
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_1', firstHighlight);
+
+      // move the second highlight up and verify
+      // list should be back to its initial order
+      await page.locator('#work_0_highlight_1_up').click();
+      await expect(page.locator('#work_0_highlight_0')).toHaveValue(firstHighlight);
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_0', firstHighlight);
+      await expect(page.locator('#work_0_highlight_1')).toHaveValue(secondHighlight);
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_1', secondHighlight);
+    });
+
+    test('Changing the order of work entries updates the resume with the correct information', async ({
+      page
+    }) => {
+      await goToWorkMenu(page);
+      const work1 = {
+        name: 'Work 1 Name',
+        position: 'Work 1 Position',
+        startDate: '2001-01',
+        endDate: '2001-12',
+        highlight: 'Work 1 highlight'
+      };
+
+      const work2 = {
+        name: 'Work 2 Name',
+        position: 'Work 2 Position',
+        startDate: '2002-01',
+        endDate: '2002-12',
+        highlight: 'Work 2 highlight'
+      };
+
+      // add first work experience
+      await page.locator('#newWork').click();
+      await page.locator('#work_0_name').fill(work1.name);
+      await page.locator('#work_0_position').fill(work1.position);
+      await page.locator('#work_0_startDate').fill(work1.startDate);
+      await page.locator('#work_0_endDate').fill(work1.endDate);
+      await page.locator('#work_0_newHighlight').click();
+      await page.locator('#work_0_highlight_0').fill(work1.highlight);
+      // add second work experience
+      await page.locator('#newWork').click();
+      await page.locator('#work_1_name').fill(work2.name);
+      await page.locator('#work_1_position').fill(work2.position);
+      await page.locator('#work_1_startDate').fill(work2.startDate);
+      await page.locator('#work_1_endDate').fill(work2.endDate);
+      await page.locator('#work_1_newHighlight').click();
+      await page.locator('#work_1_highlight_0').fill(work2.highlight);
+
+      // swap work
+      await page.locator('#work_0_down').click();
+
+      // verify the swap is correct in the menu
+      await expect(page.locator('#work_0_header')).toHaveText(work2.name);
+      await expect(page.locator('#work_0_name')).toHaveValue(work2.name);
+      await expect(page.locator('#work_0_position')).toHaveValue(work2.position);
+      await expect(page.locator('#work_0_startDate')).toHaveValue(work2.startDate);
+      await expect(page.locator('#work_0_endDate')).toHaveValue(work2.endDate);
+      await expect(page.locator('#work_0_highlight_0')).toHaveValue(work2.highlight);
+
+      await expect(page.locator('#work_1_header')).toHaveText(work1.name);
+      await expect(page.locator('#work_1_name')).toHaveValue(work1.name);
+      await expect(page.locator('#work_1_position')).toHaveValue(work1.position);
+      await expect(page.locator('#work_1_startDate')).toHaveValue(work1.startDate);
+      await expect(page.locator('#work_1_endDate')).toHaveValue(work1.endDate);
+      await expect(page.locator('#work_1_highlight_0')).toHaveValue(work1.highlight);
+
+      // verify the swap is correct in the resume component
+      await expect(page.locator('#resume_work_0_name')).toHaveValue(work2.name);
+      await expect(page.locator('#resume_work_0_position')).toHaveValue(work2.position);
+      await expect(page.locator('#resume_work_0_startDate')).toHaveValue(work2.startDate);
+      await expect(page.locator('#resume_work_0_endDate')).toHaveValue(work2.endDate);
+      await expect(page.locator('#resume_work_0_highlight_0')).toHaveValue(work2.highlight);
+
+      await expect(page.locator('#resume_work_1_name')).toHaveValue(work1.name);
+      await expect(page.locator('#resume_work_1_position')).toHaveValue(work1.position);
+      await expect(page.locator('#resume_work_1_startDate')).toHaveValue(work1.startDate);
+      await expect(page.locator('#resume_work_1_endDate')).toHaveValue(work1.endDate);
+      await expect(page.locator('#resume_work_1_highlight_0')).toHaveValue(work1.highlight);
+    });
   });
 });

--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -15,6 +15,12 @@ async function addWorkExperience(page: Page) {
   await page.click('#newWork');
 }
 
+async function expectToBeVisibleAndHaveText(page: Page, id: string, text: string) {
+  const l = page.locator(id);
+  await expect(l).toBeVisible();
+  await expect(l).toHaveText(text);
+}
+
 test.describe('Work experience menu input', () => {
   test('#14 Work highlights do not duplicate when creating new work object', async ({ page }) => {
     await goToWorkMenu(page);
@@ -52,16 +58,48 @@ test.describe('Work experience menu input', () => {
       page
     }) => {
       await addWorkExperience(page);
-      async function expectToBeVisibleAndHaveText(id: string, text: string) {
-        const l = page.locator(id);
-        await expect(l).toBeVisible();
-        await expect(l).toHaveText(text);
+
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_position', 'Position');
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_name', 'Name');
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_startDate', 'Start date');
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_endDate', 'End date');
+      await expectToBeVisibleAndHaveText(
+        page,
+        '#resume_work_0_highlight_placeholder',
+        'Highlights'
+      );
+    });
+
+    test('Updating fields in work menu correctly updates fields in resume component', async ({
+      page
+    }) => {
+      await addWorkExperience(page);
+
+      /**
+       * @param p
+       * @param inputId id of the input field without the '#' character
+       * @param inputText
+       * @param expectedText
+       */
+      async function fillAndVerify(
+        p: Page,
+        inputId: string,
+        inputText: string,
+        expectedText = inputText
+      ) {
+        await p.locator(`#${inputId}`).fill(inputText);
+        await expectToBeVisibleAndHaveText(p, `#resume_${inputId}`, expectedText);
       }
-      await expectToBeVisibleAndHaveText('#resume_work_0_position', 'Position');
-      await expectToBeVisibleAndHaveText('#resume_work_0_name', 'Name');
-      await expectToBeVisibleAndHaveText('#resume_work_0_startDate', 'Start date');
-      await expectToBeVisibleAndHaveText('#resume_work_0_endDate', 'End date');
-      await expectToBeVisibleAndHaveText('#resume_work_0_highlight_placeholder', 'Highlights');
+
+      await fillAndVerify(page, 'work_0_position', 'Position');
+      await fillAndVerify(page, 'work_0_name', 'Name');
+      await fillAndVerify(page, 'work_0_startDate', '2000-01', 'January 2000');
+      await fillAndVerify(page, 'work_0_startDate', '2000-12', 'December 2000');
+
+      await page.locator('#work_0_newHighlight').click();
+      const highlightText = 'A new highlight';
+      await page.locator('#work_0_highlight_0').fill(highlightText);
+      await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_0', highlightText);
     });
   });
 });

--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -113,5 +113,22 @@ test.describe('Work experience menu input', () => {
       await expect(page.locator('#work_0_highlight_0')).not.toBeVisible();
       await expect(page.locator('#resume_work_0_highlight_0')).not.toBeVisible();
     });
+
+    test('Adding and removing a tag to a highlight should show and hide the tag below the highlight respectively', async ({
+      page
+    }) => {
+      await addWorkExperience(page);
+      await page.locator('#work_0_newHighlight').click();
+      const tagName = 'tagName';
+      const tagsInput = page.locator('#work_0_highlight_0_tags_input');
+      await tagsInput.type(tagName);
+      await tagsInput.press('Enter');
+      const tagId = `#work_0_highlight_0_tag_${tagName}`;
+      // test if the tag showed up
+      await expectToBeVisibleAndHaveText(page, tagId, tagName);
+      // remove the tag and test if it's gone
+      await page.locator(`#work_0_highlight_0_delete_tag_${tagName}`).click();
+      await expect(page.locator(tagId)).not.toBeVisible();
+    });
   });
 });

--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -10,6 +10,11 @@ async function goToWorkMenu(page: Page) {
   await page.locator('#menu-resume-work-button').click();
 }
 
+async function addWorkExperience(page: Page) {
+  await goToWorkMenu(page);
+  await page.click('#newWork');
+}
+
 test.describe('Work experience menu input', () => {
   test('#14 Work highlights do not duplicate when creating new work object', async ({ page }) => {
     await goToWorkMenu(page);
@@ -39,6 +44,24 @@ test.describe('Work experience menu input', () => {
       expect(
         await page.evaluate('document.getElementById("work_0_startDate").checkValidity()')
       ).toBe(false);
+    });
+  });
+
+  test.describe('Work menu operations and resume display syncing', () => {
+    test('Adding work experience shows a blank work experience entry with placeholder info in the resume', async ({
+      page
+    }) => {
+      await addWorkExperience(page);
+      async function expectToBeVisibleAndHaveText(id: string, text: string) {
+        const l = page.locator(id);
+        await expect(l).toBeVisible();
+        await expect(l).toHaveText(text);
+      }
+      await expectToBeVisibleAndHaveText('#resume_work_0_position', 'Position');
+      await expectToBeVisibleAndHaveText('#resume_work_0_name', 'Name');
+      await expectToBeVisibleAndHaveText('#resume_work_0_startDate', 'Start date');
+      await expectToBeVisibleAndHaveText('#resume_work_0_endDate', 'End date');
+      await expectToBeVisibleAndHaveText('#resume_work_0_highlight_placeholder', 'Highlights');
     });
   });
 });

--- a/e2e/menuWorkExperience.spec.ts
+++ b/e2e/menuWorkExperience.spec.ts
@@ -101,5 +101,17 @@ test.describe('Work experience menu input', () => {
       await page.locator('#work_0_highlight_0').fill(highlightText);
       await expectToBeVisibleAndHaveText(page, '#resume_work_0_highlight_0', highlightText);
     });
+
+    test('Removing a highlight from a work field should update the resume components list correctly', async ({
+      page
+    }) => {
+      await addWorkExperience(page);
+      await page.locator('#work_0_newHighlight').click();
+      await page.locator('#work_0_highlight_0').fill('Some highlight that I will delete.');
+      page.on('dialog', (dialog) => dialog.accept()); // click ok when the delete confirmation dialog occurs
+      await page.locator('#work_0_highlight_0_delete').click();
+      await expect(page.locator('#work_0_highlight_0')).not.toBeVisible();
+      await expect(page.locator('#resume_work_0_highlight_0')).not.toBeVisible();
+    });
   });
 });

--- a/src/app.html
+++ b/src/app.html
@@ -13,6 +13,6 @@
     %sveltekit.head%
   </head>
   <body>
-    %sveltekit.body%
+    <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/components/highlightsSubMenu.svelte
+++ b/src/components/highlightsSubMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import IconButton from '@src/components/iconButton.svelte';
-  import { newWorkStores, saveResumeDataToLocalStorage, type Highlight } from '@src/data/data';
+  import { workStore, saveResumeDataToLocalStorage, type Highlight } from '@src/data/data';
   import { getTag, addTag, Tag } from '@src/data/tag';
   import { arrayMove } from '@src/util/arrayMove';
 
@@ -8,7 +8,7 @@
   export let i: number;
 
   function addHighlight() {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       workArray[i].highlights.push({
         visible: true,
         content: '',
@@ -20,7 +20,7 @@
 
   function deleteHighlight(k: number) {
     if (window.confirm('Are you sure you would like to delete this highlight?')) {
-      newWorkStores.update((workArray) => {
+      workStore.update((workArray) => {
         workArray[i].highlights.splice(k, 1);
         return workArray;
       });
@@ -28,7 +28,7 @@
   }
 
   function hideHighlight(k: number) {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       const visible = workArray[i].highlights[k].visible;
       workArray[i].highlights[k].visible = !visible;
       return workArray;
@@ -36,7 +36,7 @@
   }
 
   function moveHighlight(k: number, up: boolean) {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       let highlights = workArray[i].highlights;
       highlights = up ? arrayMove(highlights, k, k - 1) : arrayMove(highlights, k, k + 1);
       workArray[i].highlights = highlights;
@@ -54,7 +54,7 @@
       }
 
       // add tag to the highlight
-      newWorkStores.update((workArray) => {
+      workStore.update((workArray) => {
         let tagNames = workArray[i].highlights[k].tagNames;
         if (tagNames == undefined) tagNames = [];
         tagNames.push(currValue);
@@ -76,7 +76,7 @@
   function onHighlightInput(e: Event, k: number) {
     const target = e.target as HTMLInputElement;
     if (target) {
-      newWorkStores.update((workArray) => {
+      workStore.update((workArray) => {
         workArray[i].highlights[k].content = target.value;
         return workArray;
       });
@@ -84,7 +84,7 @@
   }
 
   function onTagDelete(k: number, tagI: number) {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       workArray[i].highlights[k].tagNames.splice(tagI, 1);
       return workArray;
     });
@@ -129,7 +129,7 @@
   <textarea
     id={`work_${i}_highlight_${k}`}
     placeholder={'A cool highlight'}
-    disabled={!$newWorkStores[i].visible || !highlight.visible}
+    disabled={!$workStore[i].visible || !highlight.visible}
     on:input={(e) => {
       onHighlightInput(e, k);
     }}>{highlight.content}</textarea

--- a/src/components/highlightsSubMenu.svelte
+++ b/src/components/highlightsSubMenu.svelte
@@ -2,13 +2,18 @@
   import IconButton from '@src/components/iconButton.svelte';
   import { newWorkStores, saveResumeDataToLocalStorage, type Highlight } from '@src/data/data';
   import { getTag, addTag, Tag } from '@src/data/tag';
+  import { arrayMove } from '@src/util/arrayMove';
 
   export let highlights: Highlight[];
   export let i: number;
 
   function addHighlight() {
     newWorkStores.update((workArray) => {
-      console.log('addHighlight');
+      workArray[i].highlights.push({
+        visible: true,
+        content: '',
+        tagNames: []
+      });
       return workArray;
     });
   }
@@ -16,7 +21,7 @@
   function deleteHighlight(k: number) {
     if (window.confirm('Are you sure you would like to delete this highlight?')) {
       newWorkStores.update((workArray) => {
-        console.log('delete Highlight');
+        workArray[i].highlights.splice(k, 1);
         return workArray;
       });
     }
@@ -24,21 +29,17 @@
 
   function hideHighlight(k: number) {
     newWorkStores.update((workArray) => {
-      console.log('hideHighlight');
+      const visible = workArray[i].highlights[k].visible;
+      workArray[i].highlights[k].visible = !visible;
       return workArray;
     });
   }
 
   function moveHighlight(k: number, up: boolean) {
     newWorkStores.update((workArray) => {
-      console.log('moveHighlight');
-      return workArray;
-    });
-  }
-
-  function updateWorkHighlight(k: number, value: string) {
-    newWorkStores.update((workArray) => {
-      workArray[i].highlights[k].content = value;
+      let highlights = workArray[i].highlights;
+      highlights = up ? arrayMove(highlights, k, k - 1) : arrayMove(highlights, k, k + 1);
+      workArray[i].highlights = highlights;
       return workArray;
     });
   }
@@ -60,6 +61,8 @@
         workArray[i].highlights[k].tagNames = tagNames;
         return workArray;
       });
+
+      target.value = '';
     }
   }
 
@@ -74,7 +77,7 @@
     const target = e.target as HTMLInputElement;
     if (target) {
       newWorkStores.update((workArray) => {
-        console.log('onHighlightInput');
+        workArray[i].highlights[k].content = target.value;
         return workArray;
       });
     }

--- a/src/components/highlightsSubMenu.svelte
+++ b/src/components/highlightsSubMenu.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import IconButton from '@src/components/iconButton.svelte';
+  import { newWorkStores, saveResumeDataToLocalStorage, type Highlight } from '@src/data/data';
+  import { getTag, addTag, Tag } from '@src/data/tag';
+
+  export let highlights: Highlight[];
+  export let i: number;
+
+  function addHighlight() {
+    newWorkStores.update((workArray) => {
+      console.log('addHighlight');
+      return workArray;
+    });
+  }
+
+  function deleteHighlight(k: number) {
+    if (window.confirm('Are you sure you would like to delete this highlight?')) {
+      newWorkStores.update((workArray) => {
+        console.log('delete Highlight');
+        return workArray;
+      });
+    }
+  }
+
+  function hideHighlight(k: number) {
+    newWorkStores.update((workArray) => {
+      console.log('hideHighlight');
+      return workArray;
+    });
+  }
+
+  function moveHighlight(k: number, up: boolean) {
+    newWorkStores.update((workArray) => {
+      console.log('moveHighlight');
+      return workArray;
+    });
+  }
+
+  function updateWorkHighlight(k: number, value: string) {
+    newWorkStores.update((workArray) => {
+      workArray[i].highlights[k].content = value;
+      return workArray;
+    });
+  }
+
+  function onTagKeydown(e: KeyboardEvent, k: number) {
+    const target: HTMLInputElement = e.target as HTMLInputElement;
+    const currValue = target ? target.value : '';
+    if (e.key == 'Enter' && currValue.length > 0) {
+      // if the tag is not in the tags, add the tag into the store
+      if (getTag(currValue) == undefined) {
+        addTag(new Tag(currValue));
+      }
+
+      // add tag to the highlight
+      newWorkStores.update((workArray) => {
+        let tagNames = workArray[i].highlights[k].tagNames;
+        if (tagNames == undefined) tagNames = [];
+        tagNames.push(currValue);
+        workArray[i].highlights[k].tagNames = tagNames;
+        return workArray;
+      });
+    }
+  }
+
+  /**
+   *
+   * @param e
+   * @param s
+   * @param k the index of the highlight that is being edited
+   * @param saveData
+   */
+  function onHighlightInput(e: Event, k: number) {
+    const target = e.target as HTMLInputElement;
+    if (target) {
+      newWorkStores.update((workArray) => {
+        console.log('onHighlightInput');
+        return workArray;
+      });
+    }
+  }
+
+  function onTagDelete(k: number, tagI: number) {
+    newWorkStores.update((workArray) => {
+      workArray[i].highlights[k].tagNames.splice(tagI, 1);
+      return workArray;
+    });
+    saveResumeDataToLocalStorage();
+  }
+</script>
+
+{#each highlights as highlight, k}
+  <label for="work_{i}_highlight_{k}">
+    New Highlight {k + 1}
+    <div class="label-controls">
+      {#if k > 0}
+        <IconButton
+          size="small"
+          id="work_{i}_highlight_{k}_up"
+          iconClass="fa-solid fa-arrow-up"
+          onclick={() => moveHighlight(k, true)}
+        />
+      {/if}
+      {#if k < highlights.length - 1}
+        <IconButton
+          size="small"
+          id="work_{i}_highlight_{k}_down"
+          iconClass="fa-solid fa-arrow-down"
+          onclick={() => moveHighlight(k, false)}
+        />
+      {/if}
+      <IconButton
+        size="small"
+        id="work_{i}_highlight_{k}_hide"
+        iconClass={highlight.visible ? 'fa-regular fa-eye' : 'fa-regular fa-eye-slash'}
+        onclick={() => hideHighlight(k)}
+      />
+      <IconButton
+        size="small"
+        id="work_{i}_highlight_{k}_delete"
+        iconClass="fa-regular fa-trash-can"
+        onclick={() => deleteHighlight(k)}
+      />
+    </div>
+  </label>
+  <textarea
+    id={`work_${i}_highlight_${k}`}
+    placeholder={'A cool highlight'}
+    disabled={!$newWorkStores[i].visible || !highlight.visible}
+    on:input={(e) => {
+      onHighlightInput(e, k);
+    }}>{highlight.content}</textarea
+  >
+  <label for={`work_${i}_highlight_${k}_tagsInput`}
+    >Add tags<span class="hint">(press Enter to submit tag)</span></label
+  >
+  <input
+    class="input-add-tags"
+    id={`work_${i}_highlight_${k}_tagsInput`}
+    type="text"
+    list="existing-tags"
+    on:keydown={(e) => onTagKeydown(e, k)}
+  />
+  <p>
+    {#each highlight.tagNames as name, ti}
+      <span id="work_{i}_highlight_{k}_tag_{name}" class="highlight-tag">
+        {name}
+        <IconButton
+          size="small"
+          id="work_{i}_highlight_{k}_delete_tag_{name}"
+          iconClass="fa-regular fa-circle-xmark"
+          onclick={() => onTagDelete(k, ti)}
+        />
+      </span>
+    {/each}
+  </p>
+{/each}
+<button id={`work_${i}_newHighlight`} class="big-btn" on:click={() => addHighlight()}>
+  Add new highlight
+</button>
+
+<style>
+  label {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .input-add-tags {
+    margin-bottom: 0;
+  }
+
+  .highlight-tag {
+    margin-top: 5px;
+    display: inline-block;
+    background: #ddd;
+    padding: 0 5px;
+    border-radius: 5px;
+    margin-right: 5px;
+  }
+</style>

--- a/src/components/highlightsSubMenu.svelte
+++ b/src/components/highlightsSubMenu.svelte
@@ -14,6 +14,7 @@
         content: '',
         tagNames: []
       });
+      saveResumeDataToLocalStorage();
       return workArray;
     });
   }
@@ -22,6 +23,7 @@
     if (window.confirm('Are you sure you would like to delete this highlight?')) {
       workStore.update((workArray) => {
         workArray[i].highlights.splice(k, 1);
+        saveResumeDataToLocalStorage();
         return workArray;
       });
     }
@@ -31,6 +33,7 @@
     workStore.update((workArray) => {
       const visible = workArray[i].highlights[k].visible;
       workArray[i].highlights[k].visible = !visible;
+      saveResumeDataToLocalStorage();
       return workArray;
     });
   }
@@ -40,6 +43,7 @@
       let highlights = workArray[i].highlights;
       highlights = up ? arrayMove(highlights, k, k - 1) : arrayMove(highlights, k, k + 1);
       workArray[i].highlights = highlights;
+      saveResumeDataToLocalStorage();
       return workArray;
     });
   }
@@ -59,6 +63,7 @@
         if (tagNames == undefined) tagNames = [];
         tagNames.push(currValue);
         workArray[i].highlights[k].tagNames = tagNames;
+        saveResumeDataToLocalStorage();
         return workArray;
       });
 
@@ -66,18 +71,12 @@
     }
   }
 
-  /**
-   *
-   * @param e
-   * @param s
-   * @param k the index of the highlight that is being edited
-   * @param saveData
-   */
   function onHighlightInput(e: Event, k: number) {
     const target = e.target as HTMLInputElement;
     if (target) {
       workStore.update((workArray) => {
         workArray[i].highlights[k].content = target.value;
+        saveResumeDataToLocalStorage();
         return workArray;
       });
     }
@@ -86,9 +85,9 @@
   function onTagDelete(k: number, tagI: number) {
     workStore.update((workArray) => {
       workArray[i].highlights[k].tagNames.splice(tagI, 1);
+      saveResumeDataToLocalStorage();
       return workArray;
     });
-    saveResumeDataToLocalStorage();
   }
 </script>
 

--- a/src/components/menus/workMenu.svelte
+++ b/src/components/menus/workMenu.svelte
@@ -1,20 +1,28 @@
 <script lang="ts">
   import MenuContents from '@src/components/menuContents.svelte';
   import WorkMenuEntry from '@src/components/workMenuEntry.svelte';
-  import { workStores, WorkStore } from '@src/data/data';
+  import { newWorkStores, createBlankWork } from '@src/data/data';
 </script>
 
 <MenuContents id="menu-resume-work">
   <h2>Work Experience</h2>
-  {#each $workStores as w, i}
-    <WorkMenuEntry {i} workStore={w} />
+  {#each $newWorkStores as w, i}
+    <WorkMenuEntry
+      {i}
+      visible={w.visible}
+      name={w.name}
+      position={w.position}
+      startDate={w.startDate}
+      endDate={w.endDate}
+      highlights={w.highlights}
+    />
   {/each}
   <button
     id="newWork"
     class="big-btn"
     on:click={() => {
-      workStores.update((w) => {
-        w.push(new WorkStore());
+      newWorkStores.update((w) => {
+        w.push(createBlankWork());
         return w;
       });
     }}>Add new work entry</button

--- a/src/components/menus/workMenu.svelte
+++ b/src/components/menus/workMenu.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import MenuContents from '@src/components/menuContents.svelte';
   import WorkMenuEntry from '@src/components/workMenuEntry.svelte';
-  import { newWorkStores, createBlankWork } from '@src/data/data';
+  import { workStore, createBlankWork } from '@src/data/data';
 </script>
 
 <MenuContents id="menu-resume-work">
   <h2>Work Experience</h2>
-  {#each $newWorkStores as w, i}
+  {#each $workStore as w, i}
     <WorkMenuEntry
       {i}
       visible={w.visible}
@@ -21,7 +21,7 @@
     id="newWork"
     class="big-btn"
     on:click={() => {
-      newWorkStores.update((w) => {
+      workStore.update((w) => {
         w.push(createBlankWork());
         return w;
       });

--- a/src/components/menus/workMenu.svelte
+++ b/src/components/menus/workMenu.svelte
@@ -1,76 +1,12 @@
 <script lang="ts">
   import MenuContents from '@src/components/menuContents.svelte';
-  import IconButton from '@src/components/iconButton.svelte';
   import WorkMenuEntry from '@src/components/workMenuEntry.svelte';
-  import { workStores, saveResumeDataToLocalStorage, WorkStore } from '@src/data/data';
-  import { arrayMove } from '@src/util/arrayMove';
-  import { get } from 'svelte/store';
-  let work = workStores;
-
-  function deleteWork(i: number, name: string) {
-    if (window.confirm(`Are you sure you would like to delete this work experience? ${name}`)) {
-      work.update((w) => {
-        w.splice(i, 1);
-        saveResumeDataToLocalStorage();
-        return w;
-      });
-    }
-  }
-
-  function hideWork(i: number) {
-    work.update((w) => {
-      const currVisibility = get(w[i].visible);
-      w[i].visible.set(!currVisibility);
-      saveResumeDataToLocalStorage();
-      return w;
-    });
-  }
-
-  function moveWork(i: number, up: boolean) {
-    work.update((w) => {
-      w = up ? arrayMove(w, i, i - 1) : arrayMove(w, i, i + 1);
-      saveResumeDataToLocalStorage();
-      return w;
-    });
-  }
+  import { workStores, WorkStore } from '@src/data/data';
 </script>
 
 <MenuContents id="menu-resume-work">
   <h2>Work Experience</h2>
-  {#each $work as w, i}
-    <h3 class="submenu-header">
-      Work {i + 1}
-      <div class="label-controls">
-        {#if i > 0}
-          <IconButton
-            size="small"
-            id="work_{i}_up"
-            iconClass="fa-solid fa-arrow-up"
-            onclick={() => moveWork(i, true)}
-          />
-        {/if}
-        {#if i < $work.length - 1}
-          <IconButton
-            size="small"
-            id="work_{i}_down"
-            iconClass="fa-solid fa-arrow-down"
-            onclick={() => moveWork(i, false)}
-          />
-        {/if}
-        <IconButton
-          size="small"
-          id="work_{i}_hide"
-          iconClass={get(w.visible) ? 'fa-regular fa-eye' : 'fa-regular fa-eye-slash'}
-          onclick={() => hideWork(i)}
-        />
-        <IconButton
-          size="small"
-          id="work_{i}_delete"
-          iconClass="fa-regular fa-trash-can"
-          onclick={() => deleteWork(i, get(w.name))}
-        />
-      </div>
-    </h3>
+  {#each $workStores as w, i}
     <WorkMenuEntry
       {i}
       visible={w.visible}
@@ -85,7 +21,7 @@
     id="newWork"
     class="big-btn"
     on:click={() => {
-      work.update((w) => {
+      workStores.update((w) => {
         w.push(new WorkStore());
         return w;
       });

--- a/src/components/menus/workMenu.svelte
+++ b/src/components/menus/workMenu.svelte
@@ -9,6 +9,7 @@
   {#each $workStores as w, i}
     <WorkMenuEntry
       {i}
+      workStore={w}
       visible={w.visible}
       name={w.name}
       position={w.position}

--- a/src/components/menus/workMenu.svelte
+++ b/src/components/menus/workMenu.svelte
@@ -7,16 +7,7 @@
 <MenuContents id="menu-resume-work">
   <h2>Work Experience</h2>
   {#each $workStores as w, i}
-    <WorkMenuEntry
-      {i}
-      workStore={w}
-      visible={w.visible}
-      name={w.name}
-      position={w.position}
-      startDate={w.startDate}
-      endDate={w.endDate}
-      highlights={w.highlights}
-    />
+    <WorkMenuEntry {i} workStore={w} />
   {/each}
   <button
     id="newWork"

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -6,7 +6,6 @@
   import { onMount } from 'svelte';
 
   let basics = basicsStore;
-  let work = workStores;
 
   const name = basics.name;
   const label = basics.label;
@@ -22,9 +21,12 @@
     const scale = fittedResumeHeight / resumeHeight;
     const resumeNode: HTMLElement | null = document.querySelector('.resume');
     const resumeOverflowNode: HTMLElement | null = document.querySelector('.overflow-warning');
-    if (resumeNode != null && resumeOverflowNode != null) {
-      const newScale = `scale(${scale * scaleControl})`;
+    const newScale = `scale(${scale * scaleControl})`;
+    if (resumeNode != null) {
       resumeNode.style.transform = newScale;
+    }
+
+    if (resumeOverflowNode != null) {
       resumeOverflowNode.style.transform = newScale;
     }
   }
@@ -50,48 +52,20 @@
       </p>
     </div>
     <div class="experience">
-      {#if $work.length > 0}
+      {#if $workStores.length > 0}
         <h3>Work Experience</h3>
         <ul>
-          {#each $work as w}
-            {#if get(w.visible) == true}
-              <WorkResumeEntry
-                name={w.name}
-                position={w.position}
-                startDate={w.startDate}
-                endDate={w.endDate}
-                highlights={w.highlights}
-              />
-            {/if}
-          {/each}
+          {#if $workStores != null}
+            {#each $workStores as w}
+              {#if get(w.visible) == true}
+                <WorkResumeEntry workStore={w} />
+              {/if}
+            {/each}
+          {/if}
         </ul>
       {:else}
         <h3 class="placeholder">Your work experience will go here.</h3>
       {/if}
-    </div>
-  </div>
-  <div class="resume overflow-warning">
-    <div class="basics">
-      <p class="name">{$name}</p>
-      <p class="subname">{$label}</p>
-      <p class="subname">{$phone}</p>
-      <p class="subname">{$email}</p>
-    </div>
-    <div class="experience">
-      <h3>Work Experience</h3>
-      <ul>
-        {#each $work as w}
-          {#if get(w.visible) == true}
-            <WorkResumeEntry
-              name={w.name}
-              position={w.position}
-              startDate={w.startDate}
-              endDate={w.endDate}
-              highlights={w.highlights}
-            />
-          {/if}
-        {/each}
-      </ul>
     </div>
   </div>
 </div>
@@ -145,12 +119,6 @@
   }
 
   /* Theme classes and such */
-
-  .resume.overflow-warning {
-    z-index: 0;
-    color: red;
-  }
-
   .basics {
     display: flex;
     flex-direction: column;

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconButton from '@src/components/iconButton.svelte';
   import WorkResumeEntry from '@src/components/resume/workResumeEntry.svelte';
-  import { basicsStore, newWorkStores } from '@src/data/data';
+  import { basicsStore, workStore } from '@src/data/data';
   import { onMount } from 'svelte';
   import { dateInputToDecoratedString } from '@src/util/resumeUtils';
 
@@ -52,11 +52,11 @@
       </p>
     </div>
     <div class="experience">
-      {#if $newWorkStores.length > 0}
+      {#if $workStore.length > 0}
         <h3>Work Experience</h3>
         <ul>
-          {#if $newWorkStores != null}
-            {#each $newWorkStores as w, i}
+          {#if $workStore != null}
+            {#each $workStore as w, i}
               {#if w.visible}
                 <WorkResumeEntry
                   {i}

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import IconButton from '@src/components/iconButton.svelte';
   import WorkResumeEntry from '@src/components/resume/workResumeEntry.svelte';
-  import { basicsStore, workStores } from '@src/data/data';
+  import { basicsStore, workStores, newWorkStores } from '@src/data/data';
   import { get } from 'svelte/store';
   import { onMount } from 'svelte';
+  import { dateInputToDecoratedString } from '@src/util/resumeUtils';
 
   let basics = basicsStore;
 
@@ -52,13 +53,20 @@
       </p>
     </div>
     <div class="experience">
-      {#if $workStores.length > 0}
+      {#if $newWorkStores.length > 0}
         <h3>Work Experience</h3>
         <ul>
-          {#if $workStores != null}
-            {#each $workStores as w, i}
-              {#if get(w.visible) == true}
-                <WorkResumeEntry workStore={w} {i} />
+          {#if $newWorkStores != null}
+            {#each $newWorkStores as w, i}
+              {#if w.visible}
+                <WorkResumeEntry
+                  {i}
+                  name={w.name}
+                  position={w.position}
+                  startDate={dateInputToDecoratedString(w.startDate, 'Start date')}
+                  endDate={dateInputToDecoratedString(w.endDate, 'End date')}
+                  highlights={w.highlights}
+                />
               {/if}
             {/each}
           {/if}

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -56,9 +56,9 @@
         <h3>Work Experience</h3>
         <ul>
           {#if $workStores != null}
-            {#each $workStores as w}
+            {#each $workStores as w, i}
               {#if get(w.visible) == true}
-                <WorkResumeEntry workStore={w} />
+                <WorkResumeEntry workStore={w} {i} />
               {/if}
             {/each}
           {/if}

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -55,20 +55,18 @@
       {#if $workStore.length > 0}
         <h3>Work Experience</h3>
         <ul>
-          {#if $workStore != null}
-            {#each $workStore as w, i}
-              {#if w.visible}
-                <WorkResumeEntry
-                  {i}
-                  name={w.name}
-                  position={w.position}
-                  startDate={dateInputToDecoratedString(w.startDate, 'Start date')}
-                  endDate={dateInputToDecoratedString(w.endDate, 'End date')}
-                  highlights={w.highlights}
-                />
-              {/if}
-            {/each}
-          {/if}
+          {#each $workStore as w, i}
+            {#if w.visible}
+              <WorkResumeEntry
+                {i}
+                name={w.name}
+                position={w.position}
+                startDate={dateInputToDecoratedString(w.startDate, 'Start date')}
+                endDate={dateInputToDecoratedString(w.endDate, 'End date')}
+                highlights={w.highlights}
+              />
+            {/if}
+          {/each}
         </ul>
       {:else}
         <h3 class="placeholder">Your work experience will go here.</h3>

--- a/src/components/resume.svelte
+++ b/src/components/resume.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import IconButton from '@src/components/iconButton.svelte';
   import WorkResumeEntry from '@src/components/resume/workResumeEntry.svelte';
-  import { basicsStore, workStores, newWorkStores } from '@src/data/data';
-  import { get } from 'svelte/store';
+  import { basicsStore, newWorkStores } from '@src/data/data';
   import { onMount } from 'svelte';
   import { dateInputToDecoratedString } from '@src/util/resumeUtils';
 

--- a/src/components/resume/workResumeEntry.svelte
+++ b/src/components/resume/workResumeEntry.svelte
@@ -5,6 +5,7 @@
   import { isHighlightVisible, dateInputToDecoratedString } from '@src/util/resumeUtils';
 
   export let workStore: WorkStore;
+  export let i: number;
   let name = derived(workStore.name, ($n) => ($n == '' ? 'Name' : $n));
   let position = derived(workStore.position, ($p) => ($p == '' ? 'Position' : $p));
   let startDate = derived(workStore.startDate, ($sd) =>
@@ -14,22 +15,29 @@
 </script>
 
 <li>
-  <span class:placeholder={$position == 'Position'}>{$position}</span>,
-  <span class:placeholder={$name == 'Name'}>{$name}</span>
+  <span id={`resume_work_${i}_position`} class:placeholder={$position == 'Position'}
+    >{$position}</span
+  >,
+  <span id={`resume_work_${i}_name`} class:placeholder={$name == 'Name'}>{$name}</span>
   <i>
-    <span class:placeholder={$startDate == 'Start date'}>{$startDate}</span> -
-    <span class:placeholder={$endDate == 'End date'}>{$endDate}</span>
+    <span id={`resume_work_${i}_startDate`} class:placeholder={$startDate == 'Start date'}
+      >{$startDate}</span
+    >
+    -
+    <span id={`resume_work_${i}_endDate`} class:placeholder={$endDate == 'End date'}
+      >{$endDate}</span
+    >
   </i>
 </li>
 <ul>
   {#if get(workStore.highlights).length > 0}
-    {#each get(workStore.highlights) as highlight}
+    {#each get(workStore.highlights) as highlight, k}
       {#if isHighlightVisible(highlight, $tagsStore)}
-        <li>{highlight.content}</li>
+        <li id={`resume_work_${i}_highlight_${k}`}>{highlight.content}</li>
       {/if}
     {/each}
   {:else}
-    <li class="placeholder">Highlights</li>
+    <li id={`resume_work_${i}_highlight_placeholder`} class="placeholder">Highlights</li>
   {/if}
 </ul>
 

--- a/src/components/resume/workResumeEntry.svelte
+++ b/src/components/resume/workResumeEntry.svelte
@@ -1,19 +1,25 @@
 <script lang="ts">
-  import type { Highlight, WorkStore } from '@src/data/data';
-  import { derived, get, type Writable } from 'svelte/store';
+  import type { WorkStore } from '@src/data/data';
+  import { derived, get } from 'svelte/store';
   import { tagsStore } from '@src/data/tag';
   import { isHighlightVisible, dateInputToDecoratedString } from '@src/util/resumeUtils';
 
   export let workStore: WorkStore;
+  let name = derived(workStore.name, ($n) => ($n == '' ? 'Name' : $n));
+  let position = derived(workStore.position, ($p) => ($p == '' ? 'Position' : $p));
+  let startDate = derived(workStore.startDate, ($sd) =>
+    dateInputToDecoratedString($sd, 'Start date')
+  );
+  let endDate = derived(workStore.endDate, ($ed) => dateInputToDecoratedString($ed, 'End date'));
 </script>
 
 <li>
-  <span class:placeholder={false}>{get(workStore.position)}</span>,
-  <span class:placeholder={false}>{get(workStore.name)}</span>
-  <i
-    ><span class:placeholder={false}>{get(workStore.startDate)}</span> -
-    <span class:placeholder={false}>{get(workStore.endDate)}</span></i
-  >
+  <span class:placeholder={$position == 'Position'}>{$position}</span>,
+  <span class:placeholder={$name == 'Name'}>{$name}</span>
+  <i>
+    <span class:placeholder={$startDate == 'Start date'}>{$startDate}</span> -
+    <span class:placeholder={$endDate == 'End date'}>{$endDate}</span>
+  </i>
 </li>
 <ul>
   {#if get(workStore.highlights).length > 0}

--- a/src/components/resume/workResumeEntry.svelte
+++ b/src/components/resume/workResumeEntry.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { Highlight, Work } from '@src/data/data';
+  import type { Highlight } from '@src/data/data';
   import { tagsStore } from '@src/data/tag';
-  import { isHighlightVisible, dateInputToDecoratedString } from '@src/util/resumeUtils';
+  import { isHighlightVisible } from '@src/util/resumeUtils';
 
   export let i: number;
   export let name: string;
@@ -9,10 +9,6 @@
   export let startDate: string;
   export let endDate: string;
   export let highlights: Highlight[];
-  // let name = work.name || "Name"
-  // let position = work.position || "Position";
-  // let startDate = dateInputToDecoratedString(work.startDate, 'Start date')
-  // let endDate = dateInputToDecoratedString(work.endDate, 'End date');
 </script>
 
 <li>

--- a/src/components/resume/workResumeEntry.svelte
+++ b/src/components/resume/workResumeEntry.svelte
@@ -1,32 +1,23 @@
 <script lang="ts">
-  import type { Highlight } from '@src/data/data';
-  import { derived, type Writable } from 'svelte/store';
+  import type { Highlight, WorkStore } from '@src/data/data';
+  import { derived, get, type Writable } from 'svelte/store';
   import { tagsStore } from '@src/data/tag';
   import { isHighlightVisible, dateInputToDecoratedString } from '@src/util/resumeUtils';
 
-  export let name: Writable<string>;
-  export let position: Writable<string>;
-  export let startDate: Writable<string>;
-  export let endDate: Writable<string>;
-  export let highlights: Writable<Array<Highlight>>;
-
-  let pos = derived(position, ($position) => ($position ? $position : 'Position'));
-  let n = derived(name, ($name) => ($name ? $name : 'Name of employer'));
-  let sd = derived(startDate, ($startDate) => dateInputToDecoratedString($startDate, 'Start date'));
-  let ed = derived(endDate, ($endDate) => dateInputToDecoratedString($endDate, 'End date'));
+  export let workStore: WorkStore;
 </script>
 
 <li>
-  <span class:placeholder={$position.length == 0}>{$pos}</span>,
-  <span class:placeholder={$name.length == 0}>{$n}</span>
+  <span class:placeholder={false}>{get(workStore.position)}</span>,
+  <span class:placeholder={false}>{get(workStore.name)}</span>
   <i
-    ><span class:placeholder={$sd == 'Start date'}>{$sd}</span> -
-    <span class:placeholder={$ed == 'End date'}>{$ed}</span></i
+    ><span class:placeholder={false}>{get(workStore.startDate)}</span> -
+    <span class:placeholder={false}>{get(workStore.endDate)}</span></i
   >
 </li>
 <ul>
-  {#if $highlights.length > 0}
-    {#each $highlights as highlight}
+  {#if get(workStore.highlights).length > 0}
+    {#each get(workStore.highlights) as highlight}
       {#if isHighlightVisible(highlight, $tagsStore)}
         <li>{highlight.content}</li>
       {/if}

--- a/src/components/resume/workResumeEntry.svelte
+++ b/src/components/resume/workResumeEntry.svelte
@@ -1,37 +1,36 @@
 <script lang="ts">
-  import type { WorkStore } from '@src/data/data';
-  import { derived, get } from 'svelte/store';
+  import type { Highlight, Work } from '@src/data/data';
   import { tagsStore } from '@src/data/tag';
   import { isHighlightVisible, dateInputToDecoratedString } from '@src/util/resumeUtils';
 
-  export let workStore: WorkStore;
   export let i: number;
-  let name = derived(workStore.name, ($n) => ($n == '' ? 'Name' : $n));
-  let position = derived(workStore.position, ($p) => ($p == '' ? 'Position' : $p));
-  let startDate = derived(workStore.startDate, ($sd) =>
-    dateInputToDecoratedString($sd, 'Start date')
-  );
-  let endDate = derived(workStore.endDate, ($ed) => dateInputToDecoratedString($ed, 'End date'));
+  export let name: string;
+  export let position: string;
+  export let startDate: string;
+  export let endDate: string;
+  export let highlights: Highlight[];
+  // let name = work.name || "Name"
+  // let position = work.position || "Position";
+  // let startDate = dateInputToDecoratedString(work.startDate, 'Start date')
+  // let endDate = dateInputToDecoratedString(work.endDate, 'End date');
 </script>
 
 <li>
-  <span id={`resume_work_${i}_position`} class:placeholder={$position == 'Position'}
-    >{$position}</span
+  <span id={`resume_work_${i}_position`} class:placeholder={position.length == 0}
+    >{position || 'Position'}</span
   >,
-  <span id={`resume_work_${i}_name`} class:placeholder={$name == 'Name'}>{$name}</span>
+  <span id={`resume_work_${i}_name`} class:placeholder={name.length == 0}>{name || 'Name'}</span>
   <i>
-    <span id={`resume_work_${i}_startDate`} class:placeholder={$startDate == 'Start date'}
-      >{$startDate}</span
+    <span id={`resume_work_${i}_startDate`} class:placeholder={startDate == 'Start date'}
+      >{startDate}</span
     >
     -
-    <span id={`resume_work_${i}_endDate`} class:placeholder={$endDate == 'End date'}
-      >{$endDate}</span
-    >
+    <span id={`resume_work_${i}_endDate`} class:placeholder={endDate == 'End date'}>{endDate}</span>
   </i>
 </li>
 <ul>
-  {#if get(workStore.highlights).length > 0}
-    {#each get(workStore.highlights) as highlight, k}
+  {#if highlights.length > 0}
+    {#each highlights as highlight, k}
       {#if isHighlightVisible(highlight, $tagsStore)}
         <li id={`resume_work_${i}_highlight_${k}`}>{highlight.content}</li>
       {/if}

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -3,7 +3,7 @@
   import {
     saveResumeDataToLocalStorage,
     type Work,
-    newWorkStores,
+    workStore,
     type Highlight
   } from '@src/data/data';
   import { arrayMove } from '@src/util/arrayMove';
@@ -25,7 +25,7 @@
   const maxDate = getDateValue();
 
   function updateWorkProperty(propname: keyof Work, value: string) {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       // I hate this method, and I wish I could just easily assign a property by array index
       // but hey, this is easier to do
       if (propname == 'name') workArray[i].name = value;
@@ -42,9 +42,9 @@
    * @param name
    */
   function deleteWork() {
-    const name = get(newWorkStores)[i].name;
+    const name = get(workStore)[i].name;
     if (window.confirm(`Are you sure you would like to delete this work experience? ${name}`)) {
-      newWorkStores.update((w) => {
+      workStore.update((w) => {
         w.splice(i, 1);
         saveResumeDataToLocalStorage();
         return w;
@@ -53,7 +53,7 @@
   }
 
   function hideWork() {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       workArray[i].visible = !workArray[i].visible;
       saveResumeDataToLocalStorage();
       return workArray;
@@ -61,7 +61,7 @@
   }
 
   function moveWork(up: boolean) {
-    newWorkStores.update((workArray) => {
+    workStore.update((workArray) => {
       workArray = up ? arrayMove(workArray, i, i - 1) : arrayMove(workArray, i, i + 1);
       saveResumeDataToLocalStorage();
       return workArray;
@@ -87,7 +87,7 @@
         onclick={() => moveWork(true)}
       />
     {/if}
-    {#if i < $newWorkStores.length - 1}
+    {#if i < $workStore.length - 1}
       <IconButton
         size="small"
         id="work_{i}_down"

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -88,11 +88,16 @@
   }
 
   function hideHighlight(k: number) {
-    workStore.highlights.update((highlights) => {
-      const currVisibility = highlights[k].visible;
-      highlights[k].visible = !currVisibility;
-      saveResumeDataToLocalStorage();
-      return highlights;
+    workStores.update((ws) => {
+      const currWorkStore = ws[i];
+      currWorkStore.highlights.update((highlights) => {
+        const currVisibility = highlights[k].visible;
+        highlights[k].visible = !currVisibility;
+        saveResumeDataToLocalStorage();
+        return highlights;
+      });
+      ws[i] = currWorkStore;
+      return ws;
     });
   }
 
@@ -116,7 +121,7 @@
    * @param k the index of the highlight that is being edited
    * @param saveData
    */
-  function onNewHighlightInput(e: Event, k: number) {
+  function onHighlightInput(e: Event, k: number) {
     const target = e.target as HTMLInputElement;
     if (target) {
       workStores.update((ws) => {
@@ -262,7 +267,7 @@
     placeholder={'A cool highlight'}
     disabled={!$visible || !highlight.visible}
     on:input={(e) => {
-      onNewHighlightInput(e, k);
+      onHighlightInput(e, k);
     }}>{highlight.content}</textarea
   >
   <label for={`work_${i}_highlight_${k}_tags_input`}

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -79,11 +79,16 @@
 
   function deleteHighlight(k: number) {
     if (window.confirm('Are you sure you would like to delete this highlight?')) {
-      // highlights.update((h) => {
-      //   h.splice(k, 1);
-      //   saveResumeDataToLocalStorage();
-      //   return h;
-      // });
+      workStores.update((ws) => {
+        const currWorkStore = ws[i];
+        currWorkStore.highlights.update((h) => {
+          h.splice(k, 1);
+          saveResumeDataToLocalStorage();
+          return h;
+        });
+        ws[i] = currWorkStore;
+        return ws;
+      });
     }
   }
 

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -281,23 +281,23 @@
       onHighlightInput(e, k);
     }}>{highlight.content}</textarea
   >
-  <label for={`work_${i}_highlight_${k}_tags_input`}
+  <label for={`work_${i}_highlight_${k}_tagsInput`}
     >Add tags<span class="hint">(press Enter to submit tag)</span></label
   >
   <input
     class="input-add-tags"
-    id={`work_${i}_highlight_${k}_tags_input`}
+    id={`work_${i}_highlight_${k}_tagsInput`}
     type="text"
     list="existing-tags"
     on:keydown={(e) => onTagKeydown(e, k)}
   />
   <p>
     {#each highlight.tagNames as name, ti}
-      <span class="highlight-tag">
+      <span id="work_{i}_highlight_{k}_tag_{name}" class="highlight-tag">
         {name}
         <IconButton
           size="small"
-          id="work-{i}-highlight-{k}-delete-tag-{name}"
+          id="work_{i}_highlight_{k}_delete_tag_{name}"
           iconClass="fa-regular fa-circle-xmark"
           onclick={() => onTagDelete(k, ti)}
         />

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -2,7 +2,7 @@
   import IconButton from '@src/components/iconButton.svelte';
   import Input from '@src/components/input.svelte';
   import { get, type Writable } from 'svelte/store';
-  import { saveResumeDataToLocalStorage, type Highlight } from '@src/data/data';
+  import { saveResumeDataToLocalStorage, workStores, type Highlight } from '@src/data/data';
   import { arrayMove } from '@src/util/arrayMove';
   import { onInput } from '@src/util/eventListeners';
   import { getDateValue } from '@src/util/getDateValue';
@@ -17,6 +17,33 @@
   export let highlights: Writable<Array<Highlight>>;
 
   const maxDate = getDateValue();
+
+  function deleteWork(i: number, name: string) {
+    if (window.confirm(`Are you sure you would like to delete this work experience? ${name}`)) {
+      workStores.update((w) => {
+        w.splice(i, 1);
+        saveResumeDataToLocalStorage();
+        return w;
+      });
+    }
+  }
+
+  function hideWork(i: number) {
+    workStores.update((w) => {
+      const currVisibility = get(w[i].visible);
+      w[i].visible.set(!currVisibility);
+      saveResumeDataToLocalStorage();
+      return w;
+    });
+  }
+
+  function moveWork(i: number, up: boolean) {
+    workStores.update((w) => {
+      w = up ? arrayMove(w, i, i - 1) : arrayMove(w, i, i + 1);
+      saveResumeDataToLocalStorage();
+      return w;
+    });
+  }
 
   function reportValidity(e: Event) {
     const target = e.target as HTMLInputElement;
@@ -93,6 +120,40 @@
     saveResumeDataToLocalStorage();
   }
 </script>
+
+<h3 class="submenu-header">
+  {#if $name}{$name}{:else}Work {i + 1}{/if}
+  <div class="label-controls">
+    {#if i > 0}
+      <IconButton
+        size="small"
+        id="work_{i}_up"
+        iconClass="fa-solid fa-arrow-up"
+        onclick={() => moveWork(i, true)}
+      />
+    {/if}
+    {#if i < $workStores.length - 1}
+      <IconButton
+        size="small"
+        id="work_{i}_down"
+        iconClass="fa-solid fa-arrow-down"
+        onclick={() => moveWork(i, false)}
+      />
+    {/if}
+    <IconButton
+      size="small"
+      id="work_{i}_hide"
+      iconClass={$visible ? 'fa-regular fa-eye' : 'fa-regular fa-eye-slash'}
+      onclick={() => hideWork(i)}
+    />
+    <IconButton
+      size="small"
+      id="work_{i}_delete"
+      iconClass="fa-regular fa-trash-can"
+      onclick={() => deleteWork(i, $name)}
+    />
+  </div>
+</h3>
 
 <Input id={`work_${i}_name`} label={'Name'} value={name} disabled={!$visible} />
 <Input id={`work_${i}_position`} label={'Position'} value={position} disabled={!$visible} />

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -26,10 +26,10 @@
    * @param k
    * @param name
    */
-  function deleteWork(k: number, name: string) {
+  function deleteWork(name: string) {
     if (window.confirm(`Are you sure you would like to delete this work experience? ${name}`)) {
       workStores.update((w) => {
-        w.splice(k, 1);
+        w.splice(i, 1);
         saveResumeDataToLocalStorage();
         return w;
       });
@@ -176,7 +176,7 @@
   }
 </script>
 
-<h3 class="submenu-header">
+<h3 id="work_{i}_header" class="submenu-header">
   {#if $name}{$name}{:else}Work {i + 1}{/if}
   <div class="label-controls">
     {#if i > 0}
@@ -205,7 +205,7 @@
       size="small"
       id="work_{i}_delete"
       iconClass="fa-regular fa-trash-can"
-      onclick={() => deleteWork(i, $name)}
+      onclick={() => deleteWork($name)}
     />
   </div>
 </h3>

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -143,7 +143,7 @@
     }
   }
 
-  function onTagKeydown(e: KeyboardEvent, highlightI: number) {
+  function onTagKeydown(e: KeyboardEvent, k: number) {
     const target: HTMLInputElement = e.target as HTMLInputElement;
     const currValue = target ? target.value : '';
     if (e.key == 'Enter' && currValue.length > 0) {
@@ -151,12 +151,18 @@
       if (getTag(currValue) == undefined) {
         addTag(new Tag(currValue));
       }
-      // add tag to a highlight
-      // highlights.update((h) => {
-      //   if (h[highlightI].tagNames == undefined) h[highlightI].tagNames = [];
-      //   h[highlightI].tagNames.push(currValue);
-      //   return h;
-      // });
+
+      workStores.update((ws) => {
+        const currWorkStore = ws[i];
+        currWorkStore.highlights.update((h) => {
+          if (h[k].tagNames == undefined) h[k].tagNames = [];
+          h[k].tagNames.push(currValue);
+          return h;
+        });
+        ws[i] = currWorkStore;
+        return ws;
+      });
+
       target.value = '';
     }
   }

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -2,19 +2,26 @@
   import IconButton from '@src/components/iconButton.svelte';
   import Input from '@src/components/input.svelte';
   import { get, type Writable } from 'svelte/store';
-  import { saveResumeDataToLocalStorage, workStores, type Highlight } from '@src/data/data';
+  import {
+    saveResumeDataToLocalStorage,
+    WorkStore,
+    workStores,
+    type Highlight
+  } from '@src/data/data';
   import { arrayMove } from '@src/util/arrayMove';
   import { onInput } from '@src/util/eventListeners';
   import { getDateValue } from '@src/util/getDateValue';
   import { Tag, addTag, getTag } from '@src/data/tag';
 
   export let i: number;
+  export let workStore: WorkStore;
   export let visible: Writable<boolean>;
   export let name: Writable<string>;
   export let position: Writable<string>;
   export let startDate: Writable<string>;
   export let endDate: Writable<string>;
   export let highlights: Writable<Array<Highlight>>;
+  let realHighlights = workStore.highlights;
 
   const maxDate = getDateValue();
 
@@ -63,7 +70,7 @@
   }
 
   function hideHighlight(i: number) {
-    highlights.update((highlights) => {
+    workStore.highlights.update((highlights) => {
       const currVisibility = highlights[i].visible;
       highlights[i].visible = !currVisibility;
       saveResumeDataToLocalStorage();
@@ -71,11 +78,16 @@
     });
   }
 
-  function moveHighlight(i: number, up: boolean) {
-    highlights.update((h) => {
-      h = up ? arrayMove(h, i, i - 1) : arrayMove(h, i, i + 1);
-      saveResumeDataToLocalStorage();
-      return h;
+  function moveHighlight(k: number, up: boolean) {
+    workStores.update((ws) => {
+      const currStore = ws[i];
+      currStore.highlights.update((h) => {
+        h = up ? arrayMove(h, k, k - 1) : arrayMove(h, k, k + 1);
+        saveResumeDataToLocalStorage();
+        return h;
+      });
+      ws[i] = currStore;
+      return ws;
     });
   }
 
@@ -179,7 +191,7 @@
   on:blur={(e) => reportValidity(e)}
 />
 
-{#each $highlights as highlight, k}
+{#each $realHighlights as highlight, k}
   <label for="work_{i}_highlight_{k}">
     New Highlight {k + 1}
     <div class="label-controls">

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -109,18 +109,27 @@
     });
   }
 
-  function onNewHighlightInput(
-    e: Event,
-    s: Writable<Highlight[]>,
-    i: number,
-    saveData: () => void
-  ) {
+  /**
+   *
+   * @param e
+   * @param s
+   * @param k the index of the highlight that is being edited
+   * @param saveData
+   */
+  function onNewHighlightInput(e: Event, k: number) {
     const target = e.target as HTMLInputElement;
     if (target) {
-      const array = get(s);
-      array[i].content = target.value;
-      s.set(array);
-      saveData();
+      workStores.update((ws) => {
+        const currWorkStore = ws[i];
+        currWorkStore.highlights.update((h) => {
+          const currHighlight = h[k];
+          currHighlight.content = target.value;
+          h[k] = currHighlight;
+          saveResumeDataToLocalStorage();
+          return h;
+        });
+        return ws;
+      });
     }
   }
 
@@ -253,9 +262,7 @@
     placeholder={'A cool highlight'}
     disabled={!$visible || !highlight.visible}
     on:input={(e) => {
-      if (e != null) {
-        onNewHighlightInput(e, highlights, k, saveResumeDataToLocalStorage);
-      }
+      onNewHighlightInput(e, k);
     }}>{highlight.content}</textarea
   >
   <label for={`work_${i}_highlight_${k}_tags_input`}

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
   import IconButton from '@src/components/iconButton.svelte';
   import Input from '@src/components/input.svelte';
-  import { derived, get, type Writable } from 'svelte/store';
-  import {
-    saveResumeDataToLocalStorage,
-    WorkStore,
-    workStores,
-    type Highlight
-  } from '@src/data/data';
+  import { derived, get } from 'svelte/store';
+  import { saveResumeDataToLocalStorage, WorkStore, workStores } from '@src/data/data';
   import { arrayMove } from '@src/util/arrayMove';
   import { onInput } from '@src/util/eventListeners';
   import { getDateValue } from '@src/util/getDateValue';
@@ -167,11 +162,16 @@
     }
   }
 
-  function onTagDelete(e: Event, highlightI: number, tagI: number) {
-    // highlights.update((h) => {
-    //   h[highlightI].tagNames.splice(tagI, 1);
-    //   return h;
-    // });
+  function onTagDelete(highlightI: number, tagI: number) {
+    workStores.update((ws) => {
+      const currWorkStore = ws[i];
+      currWorkStore.highlights.update((h) => {
+        h[highlightI].tagNames.splice(tagI, 1);
+        return h;
+      });
+      ws[i] = currWorkStore;
+      return ws;
+    });
     saveResumeDataToLocalStorage();
   }
 </script>
@@ -299,7 +299,7 @@
           size="small"
           id="work-{i}-highlight-{k}-delete-tag-{name}"
           iconClass="fa-regular fa-circle-xmark"
-          onclick={(e) => onTagDelete(e, k, ti)}
+          onclick={() => onTagDelete(k, ti)}
         />
       </span>
     {/each}

--- a/src/components/workMenuEntry.svelte
+++ b/src/components/workMenuEntry.svelte
@@ -24,14 +24,18 @@
 
   const maxDate = getDateValue();
 
-  function updateWorkProperty(propname: keyof Work, value: string) {
+  function updateWorkProperty(e: Event, propname: keyof Work) {
+    const target = e.target as HTMLInputElement;
+    if (target == null) return;
     workStore.update((workArray) => {
+      const value = target.value;
       // I hate this method, and I wish I could just easily assign a property by array index
       // but hey, this is easier to do
       if (propname == 'name') workArray[i].name = value;
       else if (propname == 'position') workArray[i].position = value;
       else if (propname == 'startDate') workArray[i].startDate = value;
       else if (propname == 'endDate') workArray[i].endDate = value;
+      saveResumeDataToLocalStorage();
       return workArray;
     });
   }
@@ -116,7 +120,7 @@
   type="text"
   disabled={!visible}
   value={name}
-  on:input={(e) => updateWorkProperty('name', e.target.value)}
+  on:input={(e) => updateWorkProperty(e, 'name')}
 />
 <label for={`work_${i}_position`}>Position</label>
 <input
@@ -124,7 +128,7 @@
   type="text"
   disabled={!visible}
   value={position}
-  on:input={(e) => updateWorkProperty('position', e.target.value)}
+  on:input={(e) => updateWorkProperty(e, 'position')}
 />
 <label for={`work_${i}_startDate`}>Start date</label>
 <input
@@ -133,7 +137,7 @@
   disabled={!visible}
   value={startDate}
   max={endDate ? endDate : maxDate}
-  on:input={(e) => updateWorkProperty('startDate', e.target.value)}
+  on:input={(e) => updateWorkProperty(e, 'startDate')}
   on:blur={(e) => reportValidity(e)}
 />
 <label for={`work_${i}_endDate`}>End date</label>
@@ -144,7 +148,7 @@
   value={endDate}
   min={startDate ? startDate : maxDate}
   max={maxDate}
-  on:input={(e) => updateWorkProperty('endDate', e.target.value)}
+  on:input={(e) => updateWorkProperty(e, 'endDate')}
   on:blur={(e) => reportValidity(e)}
 />
 <HighlightsSubMenu {highlights} {i} />

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -62,8 +62,6 @@ export type Work = {
   highlights: Highlight[];
 };
 
-export type NewWork = Work;
-
 export function createBlankWork(): Work {
   return {
     visible: true,
@@ -130,11 +128,7 @@ export function saveResumeDataToLocalStorage(basics: BasicsStore = basicsStore, 
   window.localStorage.setItem('saveData', JSON.stringify(data));
 }
 
-export function loadData(
-  saveDataString: string,
-  basics: BasicsStore = basicsStore,
-  workStore = workStore
-) {
+export function loadData(saveDataString: string, basics = basicsStore, work = workStore) {
   const saveData: SaveData = JSON.parse(saveDataString);
   try {
     // load basic data
@@ -151,7 +145,7 @@ export function loadData(
     saveData.work.forEach((work) => {
       workStoresArray.push(work);
     });
-    workStore.set(workStoresArray);
+    work.set(workStoresArray);
   } catch (e) {
     if (e instanceof TypeError) {
       console.error(

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -62,6 +62,8 @@ export type Work = {
   highlights: Highlight[];
 };
 
+export type NewWork = Work;
+
 export function createBlankWork(): Work {
   return {
     visible: true,
@@ -215,3 +217,4 @@ export function clearResumeStores() {
 
 export const basicsStore = new BasicsStore();
 export const workStores: Writable<WorkStore[]> = writable([]);
+export const newWorkStores: Writable<Work[]> = writable([]);

--- a/src/routes/proto/+page.svelte
+++ b/src/routes/proto/+page.svelte
@@ -19,18 +19,6 @@
   const barStore: Writable<Bar[]> = writable([{ content: 'three' }, { content: 'four' }]);
 
   /**
-   * changing the string store inside the foo word without updating the fooStore doesn't
-   * update the fooStore properly. This looks like what is going on with my actual app.
-   */
-  function modifyFooWord(e: Event, strStore: Writable<string>): void {
-    const target = e.target as HTMLInputElement;
-    if (target) {
-      const value = target.value;
-      strStore.set(value);
-    }
-  }
-
-  /**
    * It's still possible to live update the content of the stores, but I need to make sure
    * I update the entire store if I want to do any updates. This makes having stores inside
    * the objects pretty pointless, since I'll be updating their contents while updating the

--- a/src/routes/proto/+page.svelte
+++ b/src/routes/proto/+page.svelte
@@ -1,7 +1,95 @@
 <script lang="ts">
-  import Menu from '@src/components/proto/menu.svelte';
-  import Main from '@src/components/proto/main.svelte';
+  import { writable, get, type Writable } from 'svelte/store';
+
+  type Foo = {
+    content: Writable<string>;
+  };
+
+  const firstContent = writable('foo');
+
+  const fooStore: Writable<Foo[]> = writable([
+    { content: firstContent },
+    { content: writable('two') }
+  ]);
+
+  type Bar = {
+    content: string;
+  };
+
+  const barStore: Writable<Bar[]> = writable([{ content: 'three' }, { content: 'four' }]);
+
+  /**
+   * changing the string store inside the foo word without updating the fooStore doesn't
+   * update the fooStore properly. This looks like what is going on with my actual app.
+   */
+  function modifyFooWord(e: Event, strStore: Writable<string>): void {
+    const target = e.target as HTMLInputElement;
+    if (target) {
+      const value = target.value;
+      strStore.set(value);
+    }
+  }
+
+  /**
+   * It's still possible to live update the content of the stores, but I need to make sure
+   * I update the entire store if I want to do any updates. This makes having stores inside
+   * the objects pretty pointless, since I'll be updating their contents while updating the
+   * entire store anyway.
+   *
+   * I can use this technique to fix the display issues for now, but I need to rethink the data
+   * of the application and implement a less confusing solution.
+   */
+  function modifyFooWordBetter(e: Event, i: number): void {
+    const target = e.target as HTMLInputElement;
+    if (target) {
+      fooStore.update((foos) => {
+        foos[i].content.set(target.value);
+        return foos;
+      });
+    }
+  }
+
+  /**
+   * Modifying the store seems pretty straightforward, as long as I know the index of
+   * the array element that I'd like to modify. Since I'm updating the barStore, everything
+   * that is observing the barStore actually updates accordingly.
+   */
+  function modifyBarWord(e: Event, i: number): void {
+    const target = e.target as HTMLInputElement;
+    if (target) {
+      const value = target.value;
+      barStore.update((bars) => {
+        bars[i].content = value;
+        return bars;
+      });
+    }
+  }
 </script>
 
-<Menu />
-<Main />
+<div class="container">
+  {#each $fooStore as foo, i}
+    <div class="row">
+      <input type="text" value={get(foo.content)} on:input={(e) => modifyFooWordBetter(e, i)} />
+      <span>{get(foo.content)}</span>
+    </div>
+  {/each}
+
+  {#each $barStore as bar, i}
+    <div class="row">
+      <input type="text" value={bar.content} on:input={(e) => modifyBarWord(e, i)} />
+      <span>{bar.content}</span>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .row {
+    display: flex;
+    width: 30%;
+  }
+</style>


### PR DESCRIPTION
Although this branch was only here to fix a bug, doing so quickly became unmanageable without messing with other behavior, so here's the sum total of what I did:
* Added e2e tests to verify the correct behavior when doing different operations in the menu. Verifies whether the data in the menu is properly reflected in the resume component.
* Change the `workStores` object from an array of `WorkStore` class objects to just an array of `Work` typed objects. The `WorkStore` class contained stores for each of the different properties, which became really difficult to manage, and unnecessary to have the functionality I wanted.
* Updated all of the functions that move, hide, delete, and create Work items, highlights, and tags to update the new `workStore` object.
* Edited unit tests to pass the correct type of data into tested functions