### PR TITLE
Save data when changing tags. Load tags properly when reloading file.

### DIFF
--- a/src/components/menu/menus/tagsMenu.svelte
+++ b/src/components/menu/menus/tagsMenu.svelte
@@ -3,7 +3,6 @@
   import IconButton from '@src/components/iconButton.svelte';
   import { tagsStore, addTag, deleteTag, Tag, updateTag, updateAllTags } from '@src/data/tag';
   import { derived, writable } from 'svelte/store';
-  import { onMount } from 'svelte';
   import { removeTagFromWorkStores, saveResumeDataToLocalStorage } from '@src/data/data';
 
   let searchTerm = writable('');
@@ -53,10 +52,6 @@
       searchTerm.set(target.value);
     }
   }
-
-  onMount(() => {
-    //loadTags();
-  });
 </script>
 
 <MenuContents id="menu-tags">

--- a/src/components/menu/menus/tagsMenu.svelte
+++ b/src/components/menu/menus/tagsMenu.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
   import MenuContents from '@src/components/menu/menuContents.svelte';
   import IconButton from '@src/components/iconButton.svelte';
-  import {
-    tagsStore,
-    addTag,
-    deleteTag,
-    loadTags,
-    Tag,
-    updateTag,
-    updateAllTags
-  } from '@src/data/tag';
+  import { tagsStore, addTag, deleteTag, Tag, updateTag, updateAllTags } from '@src/data/tag';
   import { derived, writable } from 'svelte/store';
   import { onMount } from 'svelte';
   import { removeTagFromWorkStores, saveResumeDataToLocalStorage } from '@src/data/data';
@@ -33,6 +25,7 @@
 
   function onTagCheckboxClicked(tag: Tag) {
     tag.visible = !tag.visible;
+    saveResumeDataToLocalStorage();
     updateTag(tag);
   }
 
@@ -41,6 +34,7 @@
     const currValue = target ? target.value : '';
     if (e.key == 'Enter' && currValue.length > 0) {
       addTag(new Tag(currValue));
+      saveResumeDataToLocalStorage();
       target.value = '';
     }
   }
@@ -49,6 +43,7 @@
     const target = e.target as HTMLInputElement;
     if (target) {
       target.checked ? updateAllTags(true) : updateAllTags(false);
+      saveResumeDataToLocalStorage();
     }
   }
 
@@ -60,7 +55,7 @@
   }
 
   onMount(() => {
-    loadTags();
+    //loadTags();
   });
 </script>
 

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -122,7 +122,7 @@ export function saveData(basics = basicsStore, work = workStore, tags = tagsStor
  * Takes data from Basics, Work, and Education stores and saves it to localStorage as a JSON blob
  */
 export function saveResumeDataToLocalStorage(
-  basics: BasicsStore = basicsStore,
+  basics = basicsStore,
   work = workStore,
   tags = tagsStore
 ) {

--- a/src/data/tag.ts
+++ b/src/data/tag.ts
@@ -1,4 +1,5 @@
 import { writable, get, type Writable } from 'svelte/store';
+import { basicsStore, saveResumeDataToLocalStorage, workStore } from './data';
 
 export class Tag {
   readonly name: string;
@@ -21,7 +22,7 @@ export function addTag(tag: Tag, store = tagsStore) {
   }
   tags.push(tag);
   store.set(tags);
-  saveTags(store);
+  saveTags();
 }
 
 export function getTag(name: string, store = tagsStore) {
@@ -38,7 +39,7 @@ export function deleteTag(name: string, store = tagsStore) {
   }
   tags.splice(iToDelete, 1);
   store.set(tags);
-  saveTags(store);
+  saveTags();
 }
 
 export function updateTag(tag: Tag, store = tagsStore) {
@@ -50,26 +51,16 @@ export function updateTag(tag: Tag, store = tagsStore) {
   }
   tags[iToUpdate] = tag;
   store.set(tags);
-  saveTags(store);
+  saveTags();
 }
 
 export function updateAllTags(visible: boolean, store = tagsStore) {
   const tags = get(store);
   tags.forEach((t) => (t.visible = visible));
   store.set(tags);
-  saveTags(store);
+  saveTags();
 }
 
-export function saveTags(store = tagsStore) {
-  const tags = get(store);
-  localStorage.setItem('tags', JSON.stringify(tags));
-}
-
-export function loadTags(store = tagsStore) {
-  const jsonString = localStorage.getItem('tags');
-  if (jsonString) {
-    store.set(JSON.parse(jsonString));
-  } else {
-    console.error('Failed to load tags from localStorage');
-  }
+export function saveTags(tags = tagsStore) {
+  saveResumeDataToLocalStorage(basicsStore, workStore, tags);
 }

--- a/tests/data/tag.spec.ts
+++ b/tests/data/tag.spec.ts
@@ -1,4 +1,5 @@
-import { Tag, addTag, deleteTag, updateTag, saveTags, loadTags } from '@src/data/tag';
+import { blankBasics } from '@src/data/data';
+import { Tag, addTag, deleteTag, updateTag, saveTags } from '@src/data/tag';
 import { type Writable, writable, get } from 'svelte/store';
 import { describe, it, expect, vi } from 'vitest';
 
@@ -69,32 +70,17 @@ describe('Tag', () => {
       });
       const mockStore = writable([new Tag('js', true), new Tag('css', false)]);
       saveTags(mockStore);
+      const expectedSaveData = {
+        basics: blankBasics,
+        work: [],
+        tags: get(mockStore)
+      };
       expect(localStorage.setItem).toHaveBeenCalledOnce();
-      expect(localStorage.setItem).toHaveBeenCalledWith('tags', JSON.stringify(get(mockStore)));
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'saveData',
+        JSON.stringify(expectedSaveData)
+      );
       vi.resetAllMocks();
-    });
-  });
-
-  describe('loadTags', () => {
-    it('should load the tags from a json string into the store', () => {
-      const mockTags = [new Tag('js', true), new Tag('css', false)];
-      const mockJsonString = JSON.stringify(mockTags);
-      vi.stubGlobal('localStorage', {
-        getItem: () => mockJsonString
-      });
-      const mockStore: Writable<Tag[]> = writable([]);
-      loadTags(mockStore);
-      expect(get(mockStore)).toEqual(mockTags);
-    });
-
-    it('should do nothing if there is no tag data in localStorage', () => {
-      vi.stubGlobal('localStorage', {
-        getItem: () => null
-      });
-      const mockStore: Writable<Tag[]> = writable([]);
-      loadTags(mockStore);
-      expect(get(mockStore)).toEqual([]);
-      expect(get(mockStore).length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
* save tags in the `saveData` object as opposed to its own `tags` object in localStorage
* adjust the tests to test the correct stuff