### PR TITLE
Pixel perfect printing

### DIFF
--- a/e2e/resume.spec.ts
+++ b/e2e/resume.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Resume component', () => {
+  test('The resume container should be 8.5 by 11 inches', async ({ page }) => {
+    const expectedWidth = 816;
+    const expectedHeight = 1056;
+
+    await page.goto('/');
+    const resumeHandle = page.locator('[data-testid="resume"]');
+    const [actualWidth, actualHeight] = await resumeHandle.evaluate((el) => [
+      el.clientWidth,
+      el.clientHeight
+    ]);
+    expect(actualWidth).toEqual(expectedWidth);
+    expect(actualHeight).toEqual(expectedHeight);
+  });
+});

--- a/src/components/resume/resume.svelte
+++ b/src/components/resume/resume.svelte
@@ -62,7 +62,7 @@
 </script>
 
 <div class="resume-container">
-  <div class="resume">
+  <div class="resume" data-testid="resume">
     <div class="basics">
       <p class="name" class:placeholder={$name.length == 0}>{$name ? $name : 'Your name'}</p>
       <p class="subname" class:placeholder={$label.length == 0}>

--- a/src/components/resume/resume.svelte
+++ b/src/components/resume/resume.svelte
@@ -143,6 +143,7 @@
     height: var(--A4height);
     background: white;
     box-shadow: 0px 0px 9px black;
+    box-sizing: border-box;
     transform: scale(1);
     transform-origin: center top;
   }

--- a/static/app.css
+++ b/static/app.css
@@ -39,23 +39,12 @@ in different components */
   }
   .resume {
     box-sizing: border-box;
-    padding: 0 !important;
     top: 0 !important;
     transform: scale(1) !important;
-    height: initial !important;
+    height: 100% !important;
     width: 100% !important;
     box-shadow: none !important;
     margin: 0 !important;
     overflow: none;
   }
-
-  /* .name {
-    font-size: 0.27in !important;
-  }
-
-  .subname,
-  ul,
-  h3 {
-    font-size: 0.16in !important;
-  } */
 }

--- a/static/app.css
+++ b/static/app.css
@@ -32,23 +32,24 @@ in different components */
   }
   .resume-container {
     position: static !important;
-    overflow: visible !important;
+    overflow: none !important;
     margin: initial !important;
     width: initial !important;
     height: initial !important;
   }
   .resume {
     box-sizing: border-box;
-    padding: var(--pointFiveIn);
+    padding: 0 !important;
     top: 0 !important;
-    transform: none !important;
-    height: var(--A4height) !important;
-    width: var(--A4width) !important;
+    transform: scale(1) !important;
+    height: initial !important;
+    width: 100% !important;
     box-shadow: none !important;
     margin: 0 !important;
+    overflow: none;
   }
 
-  .name {
+  /* .name {
     font-size: 0.27in !important;
   }
 
@@ -56,5 +57,5 @@ in different components */
   ul,
   h3 {
     font-size: 0.16in !important;
-  }
+  } */
 }

--- a/static/app.css
+++ b/static/app.css
@@ -26,25 +26,20 @@ in different components */
 @media print {
   #open-button,
   .menu,
-  .controls-container,
-  .resume-overflow-warning {
+  .controls-container {
     display: none !important;
   }
   .resume-container {
-    position: static !important;
-    overflow: none !important;
-    margin: initial !important;
-    width: initial !important;
-    height: initial !important;
+    position: static;
+    overflow: visible;
+    margin: initial;
+    width: initial;
+    height: initial;
   }
   .resume {
     box-sizing: border-box;
     top: 0 !important;
-    transform: scale(1) !important;
-    height: 100% !important;
-    width: 100% !important;
+    transform: none !important;
     box-shadow: none !important;
-    margin: 0 !important;
-    overflow: none;
   }
 }

--- a/tests/components/resume.spec.ts
+++ b/tests/components/resume.spec.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('Resume component tests', () => {
-  it('placeholder', () => {
-    expect(true).toBe(true);
-  });
-});


### PR DESCRIPTION
Fixes #47 

Modified the CSS to no longer use custom text resizing, and get pixel perfect rendering of the resume onto a page. Note that the margins are baked into the document, so you'll need let your browser know to turn off margins when you're printing a document.