### PR TITLE
Add specific height to basics section of resume.

### DIFF
--- a/static/themes/default.css
+++ b/static/themes/default.css
@@ -14,7 +14,7 @@
   font-size: calc(var(--resume-scale) * var(--body-font-size));
 
   display: grid;
-  grid-template-rows: [header-start] auto [content-start] auto [content-end];
+  grid-template-rows: [header-start] 10% [content-start] auto [content-end];
   grid-template-columns: [primary-content-start] 70% [secondary-content-start] auto;
   gap: calc(var(--resume-scale) * var(--gap-size));
 }

--- a/static/themes/monospace.css
+++ b/static/themes/monospace.css
@@ -14,7 +14,7 @@
   font-size: calc(var(--resume-scale) * var(--body-font-size));
 
   display: grid;
-  grid-template-rows: [header-start] auto [content-start] auto [content-end];
+  grid-template-rows: [header-start] 10% [content-start] auto [content-end];
   grid-template-columns: [primary-content-start] 70% [secondary-content-start] auto;
   gap: calc(var(--resume-scale) * var(--gap-size));
 }


### PR DESCRIPTION
There was a visual bug where the bottom section of the resume would not take up the expected amount of space if there was no work experience, awkwardly placing "Add your work experience here" in the center of the document, rather than on the top of it. This change fixes that.