### PR TITLE
Support lower case searches in skills

### DIFF
--- a/src/components/form/skillsSection.svelte
+++ b/src/components/form/skillsSection.svelte
@@ -5,7 +5,7 @@
 
   let searchTerm = writable('');
   let filteredTags = derived([tagsStore, searchTerm], ([$tagsStore, $searchTerm]) =>
-    $tagsStore.filter((tag) => tag.name.includes($searchTerm))
+    $tagsStore.filter((tag) => tag.name.toLowerCase().includes($searchTerm))
   );
 
   function updateSearchTerm(e: Event) {


### PR DESCRIPTION
I should be able to search for terms without worrying about making sure my search term is the correct case. This fixes that issue.