### PR TITLE
Support importing JSON Resume

### DIFF
--- a/src/components/form/importSection.svelte
+++ b/src/components/form/importSection.svelte
@@ -52,6 +52,7 @@
         } else {
           const jsonResume = JSON.parse(e.target.result as string) as JsonResume;
           importJsonResume(jsonResume);
+          saveResumeDataToLocalStorage();
         }
       };
       fr.readAsText(file);
@@ -68,9 +69,7 @@
     >
   </p>
 
-  <button on:click={requestJsonResumeFile} id="import-jsonresume-data"
-    >Import JSON Resume</button
-  >
+  <button on:click={requestJsonResumeFile} id="import-jsonresume-data">Import JSON Resume</button>
   <input
     id="import-jsonresume-data-input"
     type="file"

--- a/src/components/form/importSection.svelte
+++ b/src/components/form/importSection.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import type { JsonResume } from '@src/data/JsonResume';
   import { loadData, saveResumeDataToLocalStorage } from '@src/data/data';
+  import importJsonResume from '@src/data/importJsonResume';
 
   function requestFile() {
     const fileUpload = document.getElementById('import-megaresume-data-input');
+    if (fileUpload != null) fileUpload.click();
+  }
+
+  function requestJsonResumeFile() {
+    const fileUpload = document.getElementById('import-jsonresume-data-input');
     if (fileUpload != null) fileUpload.click();
   }
 
@@ -10,6 +17,8 @@
    * Loads a MegaResume Json file
    * @param {Event} e an event that is triggered by an HTMLInputElement
    */
+  const fileUpload = document.getElementById('import-megaresume-data-input');
+  if (fileUpload != null) fileUpload.click();
   function loadFile(e: Event) {
     const target = e.target as HTMLInputElement;
     const file = target?.files?.[0];
@@ -27,18 +36,48 @@
       fr.readAsText(file);
     }
   }
+
+  /**
+    Loads a Json Resume file into MegaResume
+    @param {Event} e fires when uploading a file
+  */
+  function loadJsonResumeFile(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const file = target?.files?.[0];
+    if (file != undefined) {
+      const fr = new FileReader();
+      fr.onload = (e) => {
+        if (e.target == null || e.target.result == null) {
+          console.error('something went wrong with loading json resume file');
+        } else {
+          const jsonResume = JSON.parse(e.target.result as string) as JsonResume;
+          importJsonResume(jsonResume);
+        }
+      };
+      fr.readAsText(file);
+    }
+  }
 </script>
 
 <section id="import">
   <h1>Import Resume</h1>
   <p class="full-width">
     MegaResume uses the JSON Resume format to import your resume. <a
-      id="what-is-json-resume"
+      id="what-is-jsonresume"
       href="https://jsonresume.org/schema/">Learn more about JSON Resume.</a
     >
   </p>
 
-  <button id="import-json-resume">Import JSON Resume (Coming soon)</button>
+  <button on:click={requestJsonResumeFile} id="import-jsonresume-data"
+    >Import JSON Resume (Coming soon)</button
+  >
+  <input
+    id="import-jsonresume-data-input"
+    type="file"
+    accept=".json"
+    style="display:none"
+    on:change={loadJsonResumeFile}
+  />
 
   <button on:click={requestFile} id="import-megaresume-data">Open MegaResume data</button>
   <input

--- a/src/components/form/importSection.svelte
+++ b/src/components/form/importSection.svelte
@@ -69,7 +69,7 @@
   </p>
 
   <button on:click={requestJsonResumeFile} id="import-jsonresume-data"
-    >Import JSON Resume (Coming soon)</button
+    >Import JSON Resume</button
   >
   <input
     id="import-jsonresume-data-input"

--- a/src/data/JsonResume.ts
+++ b/src/data/JsonResume.ts
@@ -1,0 +1,399 @@
+/**
+ * Borrowed this file from https://github.com/jsonresume/resume-schema/issues/327#issuecomment-894813959
+ */
+
+interface Occupation {
+  /**
+   * The start date of the occupation.
+   */
+  startDate?: string;
+
+  /**
+   * The end date of the occupation. If undefined or null, may be interpretted
+   * as "Present" by implementations.
+   */
+  endDate?: string;
+}
+
+/**
+ * Résumé of an individual defined using the JSON Resume schema.
+ *
+ * @see {@link https://jsonresume.org/}
+ */
+export interface JsonResume {
+  /** Version of JSON schema is defined against. */
+  $schema?: URL;
+
+  /** Basic information of an individual. */
+  basics?: Basic;
+
+  /** Work history. */
+  work?: Work[];
+
+  /** Volunteering experience. */
+  volunteer?: Volunteer[];
+
+  /** Education history. */
+  education?: Education[];
+
+  /** Awards received throughout one's professional career. */
+  awards?: Award[];
+
+  /** Certificates received throughout one's professional career. */
+  certificates?: Certificate[];
+
+  /** Publications throughout one's career. */
+  publications?: Publication[];
+
+  /** Professional skills. */
+  skills?: Skill[];
+
+  /** List of languages one speaks. */
+  languages?: Language[];
+
+  /** List of interests one has. */
+  interests?: Interest[];
+
+  /** List of references one has received */
+  references?: Reference[];
+
+  /** Projects one has participated in. */
+  projects?: Project[];
+
+  /** The schema version and any other tooling configuration lives here. */
+  meta?: Meta;
+}
+
+/** Basic information of an individual.  */
+interface Basic {
+  /**
+   * Name of the individual.
+   *
+   * @see {@link https://www.w3.org/International/questions/qa-personal-names}
+   */
+  name?: string;
+
+  /**
+   * The primary position of the individual.
+   *
+   * For example: Web Developer
+   */
+  label?: string;
+
+  /** URL to an a JPEG or PNG image. */
+  image?: URL;
+
+  /**
+   * Email address to contact the individual.
+   *
+   * For example: thomas@jsonresume.org
+   */
+  email?: string;
+
+  /**
+   * Phone numbers, can be specified in any format.
+   *
+   * For example: 712-117-2923 or +44 7267038141
+   */
+  phone?: string;
+
+  /**
+   * URL to the individuals website.
+   *
+   * For example: a portfolio or personal homepage
+   */
+  url?: URL;
+
+  /** A short bio about the individual. */
+  summary?: string;
+
+  /** Where the individual is located. */
+  location?: Location;
+
+  /** An array of social media networks the individual is on. */
+  profiles?: Profile[];
+}
+
+/** The address to a physical location. */
+interface Location {
+  /**
+   * To add multiple address lines, use \n.
+   *
+   * For example: 1234 Glücklichkeit Straße\nHinterhaus 5. Etage li.
+   */
+  address?: string;
+
+  /** Postal code for the location. */
+  postalCode?: string;
+
+  city?: string;
+
+  /**
+   * ISO-3166-1 ALPHA-2 code for the country.
+   *
+   * For example: US, AU, IN
+   */
+  countryCode?: string;
+
+  /** The general region where you live. Can be a state, county, or province. */
+  region?: string;
+}
+
+/** Social media profile. */
+interface Profile {
+  /**
+   * The name of the network or platform.
+   *
+   * For example: Facebook or Twitter
+   */
+  network?: string;
+
+  /**
+   * Username on the platform.
+   *
+   * For example: elonmusk
+   */
+  username?: string;
+
+  /**
+   * URL to the profile on the platform.
+   *
+   * For example: https://twitter.com/elonmusk
+   * */
+  url?: URL;
+}
+
+/** A work entry on the résumé. */
+interface Work extends Occupation {
+  /**
+   * The name of the organization.
+   *
+   * For example: Facebook
+   */
+  name?: string;
+
+  /** e.g. Menlo Park, CA */
+  location?: string;
+
+  /** e.g. Social Media Company */
+  description?: string;
+
+  /** e.g. Software Engineer */
+  position?: string;
+
+  /** e.g. https://facebook.com */
+  url?: URL;
+
+  /** An overview of the responsibilities at the organization. */
+  summary?: string;
+
+  /** Accomplishments achieved during the position. */
+  highlights?: string[];
+}
+
+interface Volunteer extends Occupation {
+  /** e.g. Facebook */
+  organization?: string;
+
+  /** e.g. Software Engineer */
+  position?: string;
+
+  /** e.g. https://facebook.example.com */
+  url?: URL;
+
+  /** Give an overview of your responsibilities at the company */
+  summary?: string;
+
+  /** Specify accomplishments and achievements */
+  highlights?: string[];
+}
+
+interface Education extends Occupation {
+  /** e.g. Massachusetts Institute of Technology */
+  institution?: string;
+
+  /** e.g. https://facebook.example.com */
+  url?: URL;
+
+  /** e.g. Arts */
+  area?: string;
+
+  /** e.g. Bachelor */
+  studyType?: string;
+
+  /** grade point average, e.g. 3.67/4.0 */
+  score?: string;
+
+  /** List notable courses/subjects */
+  courses?: string[];
+}
+
+interface Award {
+  /** e.g. One of the 100 greatest minds of the century */
+  title?: string;
+
+  date?: Date;
+
+  /** e.g. Time Magazine */
+  awarder?: string;
+
+  /** e.g. Received for my work with Quantum Physics */
+  summary?: string;
+}
+
+interface Certificate {
+  /** e.g. Certified Kubernetes Administrator */
+  name?: string;
+
+  /** e.g. 1989-06-12 */
+  date?: string;
+
+  /** e.g. https://example.com */
+  url?: URL;
+
+  /** e.g. CNCF */
+  issuer?: string;
+}
+
+interface Publication {
+  /** e.g. The World Wide Web */
+  name?: string;
+
+  /** e.g. IEEE, Computer Magazine */
+  publisher?: string;
+
+  releaseDate?: Date;
+
+  /** e.g. https://www.computer.org.example.com/csdl/mags/co/1996/10/rx069-abs.html */
+  url?: URL;
+
+  /** Short summary of publication. e.g. Discussion of the World Wide Web, HTTP, HTML. */
+  summary?: string;
+}
+
+/** A skill and description of mastery. */
+interface Skill {
+  /**
+   * The name of the skill.
+   *
+   * For example: Web Development
+   */
+  name?: string;
+
+  /**
+   * A word that describes the level of mastery of the skill.
+   *
+   * For example: Master
+   */
+  level?: string;
+
+  /** Keywords pertaining to this skill. */
+  keywords?: string[];
+}
+
+/** Fluency of a language. */
+interface Language {
+  /**
+   * The display friendly name of a language.
+   *
+   * For example: English or Spanish
+   */
+  language?: string;
+
+  /**
+   * The level of fluency in the language.
+   *
+   * For example: Fluent or Beginner
+   */
+  fluency?: string;
+}
+
+/** Interest or hobby an individual may have. */
+interface Interest {
+  /**
+   * Name of the interest.
+   *
+   * For example: Philosophy
+   */
+  name?: string;
+
+  keywords?: string[];
+}
+
+/** A reference on the résumé.  */
+interface Reference {
+  /** The name of the individual or entity that made the statement. */
+  name?: string;
+
+  /**
+   * For example: Joe blogs was a great employee, who turned up to work at
+   * least once a week. He exceeded my expectations when it came to doing
+   * nothing. */
+  reference?: string;
+}
+
+/**
+ * A project an individual may've particpated in during their professional
+ * career.
+ */
+interface Project extends Occupation {
+  /**
+   * The name of the project.
+   *
+   * For example: JSON Resume
+   */
+  name?: string;
+
+  /**
+   * A short summary of project.
+   *
+   * For example: Collated works of 2017.
+   */
+  description?: string;
+
+  /** What the individual achieved during the project. */
+  highlights?: string[];
+
+  /** Key elements or technologies involved. */
+  keywords?: string[];
+
+  /**
+   * Where the project or information about the project can be found.
+   *
+   * For example: https://www.computer.org/csdl/mags/co/1996/10/rx069-abs.html
+   */
+  url?: URL;
+
+  /** The role on this project or in the company. */
+  roles?: string[];
+
+  /**
+   * Relevant entity/organization affiliations.
+   *
+   * For example: greenpeace or corporationXYZ
+   */
+  entity?: string;
+
+  /**
+   * For example: volunteering, presentation, talk, application, or conference
+   */
+  type?: string;
+}
+
+/** Metadata for a résumé. */
+interface Meta {
+  /** URL to the latest version of this document. */
+  canonical?: URL;
+
+  /**
+   * The version, should follow semantic versioning.
+   *
+   * For example: v1.0.0
+   *
+   * @see {@link https://semver.org/}
+   */
+  version?: string;
+
+  /** The date that the résumé was last modified. */
+  lastModified?: Date;
+}

--- a/src/data/importJsonResume.ts
+++ b/src/data/importJsonResume.ts
@@ -8,6 +8,7 @@ import {
   educationStore,
   type Education
 } from './data';
+import { Tag, tagsStore } from './tag';
 import type { JsonResume } from './JsonResume';
 
 /**
@@ -22,11 +23,13 @@ export default function importJsonResume(
   jsonResume: JsonResume,
   basics: BasicsStore = basicsStore,
   work: Writable<Work[]> = workStore,
-  education: Writable<Education[]> = educationStore
+  education: Writable<Education[]> = educationStore,
+  skills: Writable<Tag[]> = tagsStore
 ) {
   importBasics(jsonResume, basics);
   importWork(jsonResume, work);
   importEducation(jsonResume, education);
+  importSkills(jsonResume, skills);
 }
 
 function importBasics(jsonResume: JsonResume, basicsStore: BasicsStore) {
@@ -114,4 +117,25 @@ function importEducation(jsonResume: JsonResume, educationStore: Writable<Educat
     newEducation.push(outEdu);
   }
   educationStore.set(newEducation);
+}
+
+function importSkills(jsonResume: JsonResume, skillsStore: Writable<Tag[]>) {
+  if (!jsonResume.skills) {
+    return;
+  }
+  const newSkillNames: Set<string> = new Set();
+  const newSkills: Array<Tag> = [];
+  for (const inSkill of jsonResume.skills) {
+    if (inSkill.name) {
+      newSkillNames.add(inSkill.name);
+    }
+    if (inSkill.keywords) {
+      inSkill.keywords.forEach((kw) => newSkillNames.add(kw));
+    }
+  }
+
+  for (const newSkillName of newSkillNames) {
+    newSkills.push(new Tag(newSkillName));
+  }
+  skillsStore.set(newSkills);
 }

--- a/src/data/importJsonResume.ts
+++ b/src/data/importJsonResume.ts
@@ -12,12 +12,12 @@ import { Tag, tagsStore } from './tag';
 import type { JsonResume } from './JsonResume';
 
 /**
-Imports the contents of a JSON Resume and adds the contents into the appropriate stores.
+  Imports the contents of a JSON Resume and adds the contents into the appropriate stores.
 
-@param jsonResume {JsonResume} The json resume as defined by the [following schema](https://jsonresume.org/schema/)
-@param [basics=basicsStore] {BasicsStore} The stores for the basic information
-@param [work=workStore] {Writable<Work[]>} The store for the work array
-@param [education=educationStore] {Writable<Education[]>} The store for the education array
+  @param jsonResume {JsonResume} The json resume as defined by the [following schema](https://jsonresume.org/schema/)
+  @param [basics=basicsStore] {BasicsStore} The stores for the basic information
+  @param [work=workStore] {Writable<Work[]>} The store for the work array
+  @param [education=educationStore] {Writable<Education[]>} The store for the education array
 */
 export default function importJsonResume(
   jsonResume: JsonResume,

--- a/src/data/importJsonResume.ts
+++ b/src/data/importJsonResume.ts
@@ -1,0 +1,118 @@
+import type { Writable } from 'svelte/store';
+import {
+  type BasicsStore,
+  workStore,
+  type Work,
+  basicsStore,
+  type Highlight,
+  educationStore,
+  type Education
+} from './data';
+import type { JsonResume } from './JsonResume';
+
+/**
+Imports the contents of a JSON Resume and adds the contents into the appropriate stores.
+
+@param jsonResume {JsonResume} The json resume as defined by the [following schema](https://jsonresume.org/schema/)
+@param [basics=basicsStore] {BasicsStore} The stores for the basic information
+@param [work=workStore] {Writable<Work[]>} The store for the work array
+@param [education=educationStore] {Writable<Education[]>} The store for the education array
+*/
+export default function importJsonResume(
+  jsonResume: JsonResume,
+  basics: BasicsStore = basicsStore,
+  work: Writable<Work[]> = workStore,
+  education: Writable<Education[]> = educationStore
+) {
+  importBasics(jsonResume, basics);
+  importWork(jsonResume, work);
+  importEducation(jsonResume, education);
+}
+
+function importBasics(jsonResume: JsonResume, basicsStore: BasicsStore) {
+  if (jsonResume.basics == undefined) {
+    console.warn('No basic information. Ignoring import');
+    return;
+  }
+  Object.getOwnPropertyNames(basicsStore);
+  if (jsonResume.basics.name) {
+    basicsStore.name.set(jsonResume.basics.name);
+  }
+  if (jsonResume.basics.label) {
+    basicsStore.label.set(jsonResume.basics.label);
+  }
+  if (jsonResume.basics.email) {
+    basicsStore.email.set(jsonResume.basics.email);
+  }
+  if (jsonResume.basics.phone) {
+    basicsStore.phone.set(jsonResume.basics.phone);
+  }
+  if (jsonResume.basics.summary) {
+    basicsStore.summary.set(jsonResume.basics.summary);
+  }
+  if (jsonResume.basics.location?.region) {
+    basicsStore.location.set(jsonResume.basics.location.region);
+  }
+}
+
+function importWork(jsonResume: JsonResume, workStore: Writable<Work[]>) {
+  if (!jsonResume.work) {
+    console.warn('No work information. Ignoring work import.');
+    return;
+  }
+  const newWork: Array<Work> = [];
+  for (const inWork of jsonResume.work) {
+    const [startYear, startMonth] = inWork.startDate ? inWork.startDate.split('-') : ['', ''];
+    const [endYear, endMonth] = inWork.endDate ? inWork.endDate.split('-') : ['', ''];
+    const highlights: Array<Highlight> = [];
+    if (inWork.highlights) {
+      inWork.highlights.forEach((h: string) => {
+        highlights.push({
+          visible: true,
+          content: h,
+          tagNames: []
+        });
+      });
+    }
+    const outWork: Work = {
+      visible: true,
+      name: inWork.name || '',
+      position: inWork.position || '',
+      url: '',
+      startMonth,
+      startYear,
+      current: false,
+      endMonth,
+      endYear,
+      summary: inWork.summary || '',
+      highlights
+    };
+    newWork.push(outWork);
+  }
+
+  workStore.set(newWork);
+}
+
+function importEducation(jsonResume: JsonResume, educationStore: Writable<Education[]>) {
+  if (!jsonResume.education) {
+    return;
+  }
+  const newEducation: Array<Education> = [];
+  for (const inEdu of jsonResume.education) {
+    const [startYear, startMonth] = inEdu.startDate ? inEdu.startDate.split('-') : ['', ''];
+    const [endYear, endMonth] = inEdu.endDate ? inEdu.endDate.split('-') : ['', ''];
+    const outEdu: Education = {
+      visible: true,
+      name: inEdu.institution || '',
+      degree: inEdu.studyType || '',
+      major: inEdu.area || '',
+      startYear,
+      startMonth,
+      current: false,
+      endYear,
+      endMonth
+    };
+    newEducation.push(outEdu);
+  }
+  educationStore.set(newEducation);
+}

--- a/src/data/importJsonResume.ts
+++ b/src/data/importJsonResume.ts
@@ -34,7 +34,6 @@ function importBasics(jsonResume: JsonResume, basicsStore: BasicsStore) {
     console.warn('No basic information. Ignoring import');
     return;
   }
-  Object.getOwnPropertyNames(basicsStore);
   if (jsonResume.basics.name) {
     basicsStore.name.set(jsonResume.basics.name);
   }

--- a/tests/data/importJsonResume.spec.ts
+++ b/tests/data/importJsonResume.spec.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { type Writable, writable, get } from 'svelte/store';
 import importJsonResume from '@src/data/importJsonResume';
 import type { JsonResume } from '@src/data/JsonResume';
+import type { Tag } from '@src/data/tag';
 
 const testResumeJson: JsonResume = {
   basics: {
@@ -45,6 +46,13 @@ const testResumeJson: JsonResume = {
       score: '4.0',
       courses: ['DB1101 - Basic SQL']
     }
+  ],
+  skills: [
+    {
+      name: 'Web Development',
+      level: 'Master',
+      keywords: ['HTML', 'CSS', 'JavaScript']
+    }
   ]
 };
 
@@ -52,9 +60,10 @@ describe('Import JSON Resume', () => {
   const mockBasicsStore = new BasicsStore();
   const mockWork: Writable<Work[]> = writable([]);
   const mockEducation: Writable<Education[]> = writable([]);
+  const mockSkills: Writable<Tag[]> = writable([]);
 
   beforeAll(() => {
-    importJsonResume(testResumeJson, mockBasicsStore, mockWork, mockEducation);
+    importJsonResume(testResumeJson, mockBasicsStore, mockWork, mockEducation, mockSkills);
     console.log('finished importJsonResume');
   });
 
@@ -100,6 +109,20 @@ describe('Import JSON Resume', () => {
       expect(edu.current).toBe(false);
       expect(edu.endYear).toBe('2013');
       expect(edu.endMonth).toBe('01');
+    }
+  });
+
+  it('should assign the skills in the JSON resume to the tagsStore', () => {
+    const isExpectedSkillName = (name: string) =>
+      name === 'HTML' || name === 'CSS' || name === 'JavaScript' || name === 'Web Development';
+    const actualSkills = get(mockSkills);
+    expect(actualSkills.length).toBe(4); // HTML, CSS, JS, and Web Development
+    for (let i = 0; i < actualSkills.length; i++) {
+      const skill = actualSkills[i];
+      expect(skill.visible).toBe(true);
+      console.log('skill.name', skill.name);
+      console.log(isExpectedSkillName(skill.name));
+      expect(isExpectedSkillName(skill.name)).toBe(true);
     }
   });
 });

--- a/tests/data/importJsonResume.spec.ts
+++ b/tests/data/importJsonResume.spec.ts
@@ -1,0 +1,105 @@
+import { BasicsStore, type Education, type Work } from '@src/data/data';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { type Writable, writable, get } from 'svelte/store';
+import importJsonResume from '@src/data/importJsonResume';
+import type { JsonResume } from '@src/data/JsonResume';
+
+const testResumeJson: JsonResume = {
+  basics: {
+    name: 'John Doe',
+    label: 'Programmer',
+    email: 'john@gmail.com',
+    phone: '(912) 555-4321',
+    summary: 'A summary of John Doe…',
+    location: {
+      address: '2712 Broadway St',
+      postalCode: 'CA 94115',
+      city: 'San Francisco',
+      countryCode: 'US',
+      region: 'California'
+    },
+    profiles: [
+      {
+        network: 'Twitter',
+        username: 'john'
+      }
+    ]
+  },
+  work: [
+    {
+      name: 'Company',
+      position: 'President',
+      startDate: '2013-01-01',
+      endDate: '2014-01-01',
+      summary: 'Description…',
+      highlights: ['Started the company']
+    }
+  ],
+  education: [
+    {
+      institution: 'University',
+      area: 'Software Development',
+      studyType: 'Bachelor',
+      startDate: '2011-01-01',
+      endDate: '2013-01-01',
+      score: '4.0',
+      courses: ['DB1101 - Basic SQL']
+    }
+  ]
+};
+
+describe('Import JSON Resume', () => {
+  const mockBasicsStore = new BasicsStore();
+  const mockWork: Writable<Work[]> = writable([]);
+  const mockEducation: Writable<Education[]> = writable([]);
+
+  beforeAll(() => {
+    importJsonResume(testResumeJson, mockBasicsStore, mockWork, mockEducation);
+    console.log('finished importJsonResume');
+  });
+
+  it('should assign the contents of the JSON Resume to the correct stores', () => {
+    expect(get(mockBasicsStore.name)).toBe('John Doe');
+    expect(get(mockBasicsStore.label)).toBe('Programmer');
+    expect(get(mockBasicsStore.email)).toBe('john@gmail.com');
+    expect(get(mockBasicsStore.phone)).toBe('(912) 555-4321');
+    expect(get(mockBasicsStore.location)).toBe('California');
+  });
+
+  it('should assign the work contents of the JSON Resume to the correct store', () => {
+    const actualWork = get(mockWork);
+    expect(actualWork.length).toBe(1);
+    for (let i = 0; i < actualWork.length; i++) {
+      const w = actualWork[i];
+      const rw = testResumeJson.work![i];
+      expect(w.visible).toBe(true);
+      expect(w.name).toBe(rw.name);
+      expect(w.position).toBe(rw.position);
+      expect(w.startMonth).toBe('01');
+      expect(w.startYear).toBe('2013');
+      expect(w.endMonth).toBe('01');
+      expect(w.endYear).toBe('2014');
+      expect(w.current).toBe(false);
+      expect(w.summary).toBe(rw.summary);
+    }
+  });
+
+  it('should assign the education contents of the JSON resume to the correct store', () => {
+    const actualEducation = get(mockEducation);
+    expect(actualEducation.length).toBe(1);
+    for (let i = 0; i < actualEducation.length; i++) {
+      const edu = actualEducation[i];
+      const redu = testResumeJson.education![i];
+      expect(redu).toBeDefined();
+      expect(edu.visible).toBe(true);
+      expect(edu.name).toBe(redu.institution);
+      expect(edu.degree).toBe(redu.studyType);
+      expect(edu.major).toBe(redu.area);
+      expect(edu.startYear).toBe('2011');
+      expect(edu.startMonth).toBe('01');
+      expect(edu.current).toBe(false);
+      expect(edu.endYear).toBe('2013');
+      expect(edu.endMonth).toBe('01');
+    }
+  });
+});


### PR DESCRIPTION
Users can now import [JSON Resumes](https://jsonresume.org/) into MegaResume. This is designed to get users to the interesting part of compiling experience and filtering based on skills rather than re-typing all their information into yet another resume tool.