### PR TITLE
Fix skill search to support lowercase searches

### DIFF
--- a/src/components/form/skillsSection.svelte
+++ b/src/components/form/skillsSection.svelte
@@ -5,7 +5,7 @@
 
   let searchTerm = writable('');
   let filteredTags = derived([tagsStore, searchTerm], ([$tagsStore, $searchTerm]) =>
-    $tagsStore.filter((tag) => tag.name.toLowerCase().includes($searchTerm))
+    $tagsStore.filter((tag) => tag.name.toLowerCase().includes($searchTerm.toLowerCase()))
   );
 
   function updateSearchTerm(e: Event) {


### PR DESCRIPTION
There was a bug when searching for skills where searches would only match skill names if they were lowercase. Fix this to allow uppercase and lowercase search terms to match.